### PR TITLE
fix(ux): Rename response field from 'kirjeldus' to 'vastus' (UX-001 & UX-002)

### DIFF
--- a/app/composables/useTaskResponseCreation.ts
+++ b/app/composables/useTaskResponseCreation.ts
@@ -106,7 +106,7 @@ export const useTaskResponseCreation = (): UseTaskResponseCreationReturn => {
 
     const responseData: ResponseData = {
       [ENTU_PROPERTIES.PARENT]: taskId,
-      [ENTU_PROPERTIES.KIRJELDUS]: responses[0]?.value || ''
+      [ENTU_PROPERTIES.VASTUS]: responses[0]?.value || ''
     }
 
     if (respondentName) {

--- a/app/constants/entu.ts
+++ b/app/constants/entu.ts
@@ -30,14 +30,17 @@ export const ENTU_TYPE_IDS = {
 
 /**
  * Entu property names used in entity creation and queries
- * Usage: responseData[ENTU_PROPERTIES.KIRJELDUS] = 'description'
+ * Usage: responseData[ENTU_PROPERTIES.VASTUS] = 'answer text'
  */
 export const ENTU_PROPERTIES = {
   // Response entity properties
-  KIRJELDUS: 'kirjeldus', // Description/response text
+  VASTUS: 'vastus', // Response text/answer
   VASTAJA: 'vastaja', // Respondent name
   GEOPUNKT: 'geopunkt', // Geographic point (lat,lng)
   ASUKOHT: 'asukoht', // Location reference
+
+  // Task entity properties
+  KIRJELDUS: 'kirjeldus', // Task description
 
   // Location entity properties
   NAME_STRING: 'name.string', // Location name

--- a/docs/model/vastus.sample.json
+++ b/docs/model/vastus.sample.json
@@ -51,10 +51,10 @@
         "entity_type": "database"
       }
     ],
-    "kirjeldus": [
+    "vastus": [
       {
         "_id": "68c7332985a9d472cca35cf9",
-        "string": "näidis kirjeldus"
+        "string": "näidis vastus"
       }
     ],
     "photo": [

--- a/types/entu.ts
+++ b/types/entu.ts
@@ -183,8 +183,8 @@ export interface EntuResponse extends EntuEntity {
   /** Location reference */
   asukoht?: EntuReferenceProperty[]
 
-  /** Response description/text */
-  kirjeldus?: EntuStringProperty[]
+  /** Response text/answer */
+  vastus?: EntuStringProperty[]
 
   /** Response photo */
   photo?: EntuFileProperty[]


### PR DESCRIPTION
## Summary

This PR addresses UX-001 and UX-002 by renaming the response field for better clarity and updating task field labels.

## Changes

### Entu Configuration (Manual - Phase 1)
- Response entity property renamed: `kirjeldus` -> `vastus`
- Response labels updated: EN="Answer", ET="Vastus"
- Task labels updated: EN="Assignment", ET="Ülesande kirjeldus"

### Code Changes (Phase 2)
- **TypeScript Types** (`types/entu.ts`): Updated `EntuResponse` interface
- **Constants** (`app/constants/entu.ts`): Reorganized ENTU_PROPERTIES, added VASTUS for responses
- **Composable** (`app/composables/useTaskResponseCreation.ts`): Updated to use VASTUS property
- **Documentation** (`docs/model/vastus.sample.json`): Updated sample data

## Testing
- Manual testing completed successfully
- TypeScript type checking passed (no errors)
- New responses created with `vastus` property
- Response submission works correctly

## Breaking Changes
None - no existing production data to migrate

## Constitutional Compliance
- Type Safety First: All TypeScript types updated and validated
- Pragmatic Simplicity: Clean, focused refactoring

## Resolves
- UX-001: "Kirjeldus" välja nimetuse segadus
- UX-002: Ülesande kirjelduse välja nimetuse segadus