### PR TITLE
feat: Add Latvian language support (FEAT-004)

### DIFF
--- a/.config/i18n.config.ts
+++ b/.config/i18n.config.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - defineI18nConfig is auto-imported by Nuxt i18n
+// @ts-expect-error - defineI18nConfig is auto-imported by Nuxt i18n
 export default defineI18nConfig(() => ({
   legacy: false,
   strategy: 'no_prefix',
@@ -423,6 +423,143 @@ export default defineI18nConfig(() => ({
       map: {
         yourLocation: 'Ваше місцезнаходження'
       }
+    },
+    lv: {
+      // Authentication
+      alreadyLoggedIn: 'Jūs jau esat pieteicies',
+      loggingIn: 'Piesakos...',
+
+      continue: 'Turpināt uz lietotni',
+      user: 'Lietotājs',
+
+      // Authentication notifications
+      auth: {
+        sessionExpired: 'Sesija beigusies',
+        sessionExpiredMessage: 'Lūdzu, piesakieties vēlreiz',
+        authRequired: 'Nepieciešama autentifikācija',
+        authRequiredMessage: 'Pārvirza uz pieteikšanās lapu...'
+      },
+      // Common
+      common: {
+        noData: 'Nav datu',
+        reload: 'Pārlādēt',
+        error: 'Kļūda',
+        retry: 'Mēģināt vēlreiz'
+      },
+      login: 'Pieteikties',
+      logout: 'Izrakstīties',
+      appName: 'ESMuseum Kartes',
+      description: 'Izpētiet Igaunijas militāro vēsturi, izmantojot interaktīvās uz atrašanās vietu balstītās misijas un vēsturiskos atklājumus. Autentificējieties, lai sāktu savu ceļojumu.',
+
+      title: 'Laipni lūdzam Igaunijas Kara muzejā',
+      redirecting: 'Pārvirza...',
+      hello: 'Sveiki',
+      student: 'skolēns',
+      clickHere: 'Noklikšķiniet šeit, ja automātiskā pārvirzīšana nenotiek',
+      tasks: {
+        loading: 'Ielādē uzdevumus...',
+        initializing: 'Inicializē...',
+        loadingTasks: 'Ielādē uzdevumus',
+        selectTask: 'Izvēlieties uzdevumu',
+        selectTaskDescription: 'Lūdzu, izvēlieties uzdevumu, lai sāktu',
+        title: 'Uzdevumi',
+        noTasks: 'Pagaidām nav neviena piešķirta uzdevuma',
+        searchTasks: 'Meklēt uzdevumus...',
+        tasksFound: '{count} uzdevums atrasts | {count} uzdevumi atrasti',
+        noTasksMatchSearch: 'Neviens uzdevums neatbilst jūsu meklēšanai',
+        tryDifferentSearch: 'Mēģiniet citu meklēšanas terminu',
+        noTasksDescription: 'Uzdevumi parādīsies šeit, kad tie tiks piešķirti',
+        responses: 'atbildes',
+        group: 'Grupa',
+        open: 'Atvērt →'
+      },
+      gps: {
+
+        requesting: 'Pieprasa atrašanās vietu',
+
+        tryAgain: 'Mēģināt vēlreiz',
+        howToEnable: 'Kā iespējot?',
+        dismiss: 'Aizvērt',
+        // New error message translations
+        error: {
+          permissionTitle: 'Nepieciešama atrašanās vietas atļauja',
+          unavailableTitle: 'Atrašanās vieta nav pieejama',
+          timeoutTitle: 'Atrašanās vietas pieprasījuma laiks iztecējis',
+          genericTitle: 'Atrašanās vietas problēma',
+          permissionDenied: 'Piekļuve atrašanās vietai tika liegta. Lūdzu, iespējojiet atrašanās vietas atļaujas un mēģiniet vēlreiz.',
+          positionUnavailable: 'Jūsu atrašanās vieta pašlaik nav pieejama. Tas var būt slikta GPS signāla vai atspējotu atrašanās vietas pakalpojumu dēļ. Mēģiniet pāriet uz vietu ar labāku signālu vai iespējojiet atrašanās vietas pakalpojumus savā ierīcē.',
+          timeout: 'Atrašanās vietas pieprasījuma laiks iztecējis. Lūdzu, mēģiniet vēlreiz vai pārliecinieties, ka jums ir labs GPS signāls.',
+          unknown: 'Nevar noteikt jūsu atrašanās vietu. Lūdzu, mēģiniet vēlāk.',
+          permissionRetry: 'Lūdzu, atļaujiet piekļuvi atrašanās vietai, lai iespējotu GPS funkcijas.',
+          permissionBlocked: 'Piekļuve atrašanās vietai ir bloķēta. Varat turpināt bez GPS vai iespējot to pārlūkprogrammas iestatījumos.',
+          continueWithoutGPS: 'Turpināt bez GPS',
+          serviceIssue: 'Radās problēma ar atrašanās vietas pakalpojumiem.'
+        }
+      },
+      taskDetail: {
+
+        responsesProgress: '{actual} / {expected} atbildes',
+        totalResponses: '{count} atbildes kopā',
+        geolocationError: 'Ģeolokācijas kļūda: {error}',
+        noTitle: 'Uzdevums bez nosaukuma',
+        selectLocation: 'Izvēlieties atrašanās vietu ({count} pieejamas)',
+
+        yourResponse: 'Jūsu atbilde',
+        addFile: 'Pievienot failu (neobligāti)',
+        allowedFiles: 'Atļauti: attēli, PDF, Word dokumenti',
+        dragDropFiles: 'Velciet failus šeit vai noklikšķiniet, lai izvēlētos',
+        maxFileSize: 'Maksimālais faila izmērs: 10MB',
+        clickToAddMore: 'Noklikšķiniet, lai pievienotu vēl failus',
+        fileTooLarge: 'Fails {name} ir pārāk liels. Maksimālais izmērs ir {maxSize}.',
+        fileTypeNotAllowed: 'Faila tips nav atļauts: {name}',
+        preparing: 'Sagatavo...',
+
+        uploadComplete: '✅ Augšupielādēts',
+        uploadFailed: '❌ Neizdevās',
+        location: 'Atrašanās vieta',
+        manualCoordinates: 'Manuālās koordinātas',
+        close: '← Aizvērt',
+        coordinatesFormat: 'Koordinātas (lat,lng formāts)',
+        coordinatesExample: 'piemēram: 59.4370, 24.7536',
+        searchingLocation: 'Meklē atrašanās vietu...',
+        useCurrentLocation: 'Izmantot pašreizējo atrašanās vietu',
+        useTheseCoordinates: 'Izmantot šīs koordinātas',
+        response: 'Atbilde',
+        responsePlaceholder: 'Rakstiet savu atbildi šeit...',
+        submitting: 'Iesniedz...',
+        submitResponseBtn: 'Iesniegt atbildi',
+        canUpdateUntilDeadline: 'Varat atjaunināt savu atbildi līdz termiņa beigām',
+        responseAlreadySubmitted: '✅ Jūsu atbilde ir iesniegta',
+        geolocationNotSupported: 'Ģeolokācija netiek atbalstīta šajā pārlūkprogrammā',
+        checkingPermissions: 'Pārbauda atļaujas...',
+        noPermission: 'Nav atļaujas',
+        noPermissionDescription: 'Jums nav atļaujas atbildēt uz šo uzdevumu. Sazinieties ar skolotāju, ja domājat, ka tas ir kļūda.',
+        // Submission modal translations
+        modalSubmitting: 'Iesniedz atbildi...',
+        modalSubmitSuccess: 'Atbilde iesniegta!',
+        modalSubmitError: 'Iesniegšanas kļūda',
+        // LocationPicker translations
+        selectedLocation: 'Izvēlētā atrašanās vieta',
+        changeLocation: 'Mainīt',
+        loadingLocationsList: 'Ielādē atrašanās vietas...',
+        searchingLocationGPS: '🔍 Meklē atrašanās vietu...',
+        searchLocations: 'Meklēt atrašanās vietas...',
+        noLocationsForTask: 'Šim uzdevumam nav definētas atrašanās vietas',
+        unnamedLocation: 'Atrašanās vieta bez nosaukuma',
+        // User location override translations
+
+        manualLocationOverride: 'Manuāla atrašanās vietas pārrakstīšana',
+        enterManually: 'Ievadīt manuāli',
+        cancel: 'Atcelt',
+        manualLocationHelp: 'Tas pārrakstīs jūsu atrašanās vietu kartes kārtošanai',
+        applyLocation: 'Lietot atrašanās vietu',
+        clearOverride: 'Notīrīt pārrakstīšanu',
+        manualLocationActive: 'Manuāla atrašanās vietas pārrakstīšana aktīva',
+        remove: 'Noņemt'
+      },
+      map: {
+        yourLocation: 'Jūsu atrašanās vieta'
+      }
     }
   },
   datetimeFormats: {
@@ -448,6 +585,16 @@ export default defineI18nConfig(() => ({
       }
     },
     uk: {
+      date: { year: 'numeric', month: '2-digit', day: '2-digit' },
+      datetime: {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+      }
+    },
+    lv: {
       date: { year: 'numeric', month: '2-digit', day: '2-digit' },
       datetime: {
         year: 'numeric',

--- a/.config/nuxt.config.ts
+++ b/.config/nuxt.config.ts
@@ -19,7 +19,7 @@ export default defineNuxtConfig({
   // Fix mobile hydration issues
   vue: {
     compilerOptions: {
-      isCustomElement: (tag) => false
+      isCustomElement: (_tag) => false
     }
   },
   spaLoadingTemplate: false,
@@ -73,7 +73,7 @@ export default defineNuxtConfig({
     vueI18n: '~~/.config/i18n.config.ts',
     defaultLocale: 'et',
     strategy: 'no_prefix',
-    locales: ['et', 'en', 'uk'],
+    locales: ['et', 'en', 'uk', 'lv'],
     detectBrowserLanguage: {
       useCookie: true,
       cookieKey: 'i18n_locale',

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -52,7 +52,7 @@
 
 <script setup lang="ts">
 // Language code type
-type LanguageCode = 'et' | 'en' | 'uk'
+type LanguageCode = 'et' | 'en' | 'uk' | 'lv'
 
 // Props
 interface Props {
@@ -84,7 +84,8 @@ interface Language {
 const allLanguages: Language[] = [
   { code: 'et', name: 'Eesti', flag: '🇪🇪' },
   { code: 'en', name: 'English', flag: '🇬🇧' },
-  { code: 'uk', name: 'Українська', flag: '🇺🇦' }
+  { code: 'uk', name: 'Українська', flag: '🇺🇦' },
+  { code: 'lv', name: 'Latviešu', flag: '🇱🇻' }
 ]
 
 // Computed property for available languages (excluding current)

--- a/app/components/TaskWorkspaceHeader.vue
+++ b/app/components/TaskWorkspaceHeader.vue
@@ -48,7 +48,7 @@
 
 <script setup lang="ts">
 // Language code type
-type LanguageCode = 'et' | 'en' | 'uk'
+type LanguageCode = 'et' | 'en' | 'uk' | 'lv'
 
 // Progress data interface
 interface ProgressData {
@@ -87,7 +87,8 @@ interface Language {
 const allLanguages: Language[] = [
   { code: 'et', name: 'Eesti', flag: '🇪🇪' },
   { code: 'en', name: 'English', flag: '🇬🇧' },
-  { code: 'uk', name: 'Українська', flag: '🇺🇦' }
+  { code: 'uk', name: 'Українська', flag: '🇺🇦' },
+  { code: 'lv', name: 'Latviešu', flag: '🇱🇻' }
 ]
 
 const languageButtons = computed<Language[]>(() => {


### PR DESCRIPTION
## Overview

Adds complete Latvian language support to the ESMuseum map application, completing FEAT-004 from the October 2025 demo feedback.

This PR includes:
- 105 Latvian translations covering all UI elements
- Translation cleanup (3 missing keys added, 20 unused keys removed)
- Latvian flag in both language switchers
- Full i18n configuration for Latvian locale
- 100% translation coverage verified

---

## Changes

### 1. Translation Cleanup (Commit 1)
**Goal**: Establish clean baseline before adding new language

- Added 3 missing translation keys:
  - `clickHere`: "Click here if not redirected automatically"
  - `tasks.initializing`: "Initializing..."
  - `tasks.loadingTasks`: "Loading tasks"

- Removed 20 unused translation keys:
  - Obsolete authentication keys
  - Deprecated UI elements
  - Legacy map-related translations

- Manually restored `tasks.loading` (false positive from automated cleanup)

**Result**: 105 defined keys = 105 used keys (perfect 1:1 match)

**Verification**: `node scripts/analyze-translations.cjs`

---

### 2. Latvian Language Support (Commit 2)

#### A. Translations (`.config/i18n.config.ts`)
- Added complete Latvian (`lv`) translations (105 keys)
- Translation strategy:
  - **Primary source**: Estonian (closest Baltic cultural context)
  - **Verification**: English for clarity
  - **Tone**: Professional, educational (museum/Interreg project context)

**Coverage areas**:
- Authentication (login, logout, session management)
- Common UI (errors, reload, retry)
- Tasks (loading, selection, search, progress)
- GPS/Location (permissions, errors, coordinates)
- Task details (responses, submissions, file uploads)
- Location picker (selection, search, manual entry)
- Map interface (your location)

#### B. Configuration (`.config/nuxt.config.ts`)
- Added `'lv'` to `locales` array: `['et', 'en', 'uk', 'lv']`
- Added Latvian datetime formats
- Fixed linting: `isCustomElement: (_tag) => false`

#### C. Language Switchers
**AppHeader.vue** (task selection page):
- Added Latvian to `LanguageCode` type: `'et' | 'en' | 'uk' | 'lv'`
- Added to `allLanguages`: `{ code: 'lv', name: 'Latviešu', flag: '🇱🇻' }`

**TaskWorkspaceHeader.vue** (task detail/map page):
- Added Latvian to `LanguageCode` type
- Added to `allLanguages` with flag

#### D. Code Quality
- Improved TypeScript comment: `@ts-ignore` to `@ts-expect-error`
  - Better practice: errors if the suppression becomes unnecessary

---

## Testing

### Verification Performed
1. **Translation coverage**: `analyze-translations.cjs` confirms 105/105 keys
2. **TypeScript**: No compilation errors
3. **Linting**: All files pass ESLint
4. **Configuration**: Nuxt i18n correctly recognizes `lv` locale

### Manual Testing Recommended
- Switch to Latvian in task selection page (header flags)
- Switch to Latvian in task detail page (workspace header flags)
- Verify all UI strings display in Latvian
- Test with browser language detection
- Verify language persistence (cookie)

---

## Impact

### Project Requirements
- Completes FEAT-004 from demo feedback
- Meets Interreg Estonia-Latvia project language requirements
- Extends user base to Latvian speakers

### Translation Metrics
- **Before**: 3 languages (et, en, uk)
- **After**: 4 languages (et, en, uk, lv)
- **Keys per language**: 105
- **Total translations**: 420 keys (4 x 105)
- **Coverage**: 100% (verified)

---

## Related

- **Demo Feedback**: `docs/demo-feedback-2025-10-08-formalized.md`
- **Issue**: FEAT-004 (Latvian language support)
- **Analysis Tool**: `scripts/analyze-translations.cjs`
- **Previous**: PR #8 (UX-001/UX-002 field naming)

---

## Remaining Demo Feedback Tasks

After this PR, 5 of 10 tasks complete:
- BUG-001: Statistics auto-refresh (PR #7)
- FEAT-005: Interreg logo (Oct 12)
- FEAT-006: Timestamp formula property (Oct 13)
- UX-001 & UX-002: Field naming (PR #8)
- **FEAT-004: Latvian language** (this PR)

Remaining:
- FEAT-001: Onboarding flow (high priority)
- FEAT-002: Email authentication (high priority)
- FEAT-003: Teacher/student workflow (high priority)
- BUG-002: Geopunkt/asukoht clarity (medium priority)
- DOC-001: Teacher guide (low priority)

---

## Constitutional Compliance

- **Type Safety**: All TypeScript types updated (`LanguageCode`)
- **Pragmatic Simplicity**: Reused existing translation structure
- **Observable Development**: Translation analysis tool validates coverage
- **Zero Trust Data**: i18n configuration follows established patterns