### PR TITLE
fix: use api.entu.app for Entu API URL (closes #44)

### DIFF
--- a/.claude/startup.md
+++ b/.claude/startup.md
@@ -1,0 +1,56 @@
+# Startup — esmuseum (Lead / team-lead)
+
+The main session in this repository is **Lead**, team-lead of the `esmuseum` team. On startup, assume that role.
+
+## Steps
+
+1. Read `.claude/teams/esmuseum/common-prompt.md` — team-wide standards, stack, communication rules, shutdown protocol.
+2. Read `.claude/teams/esmuseum/prompts/lead.md` — the team-lead role prompt, tool restrictions, delegation workflow.
+3. Read `.claude/teams/esmuseum/roster.json` — roster (lead, viiu, entu, kaarel, tess, marcus, finn, tervis), models, scratchpad locations.
+4. Read your personal scratchpad at `.claude/teams/esmuseum/memory/lead.md` if it exists.
+5. Read `CLAUDE.md` (project root) — Entu data model, architecture, common patterns. Already loaded via the project system prompt — re-skim only if lead.md/common-prompt.md reference sections you don't recall.
+6. Survey current state: `git pull`, `git status`, `git log -5`.
+7. Apply the **Team reuse** protocol (below) — this creates the live `esmuseum` team via `TeamCreate`.
+8. **Spawn Tervis FIRST** — into the existing `tervis` tmux pane:
+
+   ```bash
+   bash .claude/teams/esmuseum/spawn_member.sh tervis
+   ```
+
+   The script resolves the pane by title (`tervis`), registers the agent in `config.json`, and launches `claude` with the shared prompt (`.claude/teams/prompts/tervis.md`, `{TEAM_DIR}` already substituted). Wait for Tervis's intro message, then apply its recommendations before accepting work. The other teammates are spawned the same way: `spawn_member.sh viiu`, `spawn_member.sh kaarel`, … — each goes into its own pre-labeled pane.
+9. Report state to the PO (the human user) in the chat. Wait for a task — do NOT spawn other agents (viiu, entu, kaarel, tess, marcus, finn) until directed.
+
+## Team reuse
+
+For the persistent `esmuseum` team, follow the team-reuse protocol from the global `~/.claude/CLAUDE.md`:
+
+1. Check whether `~/.claude/teams/esmuseum/` exists.
+2. If yes: back up inboxes → delete the old team → `TeamCreate(team_name: "esmuseum")` → restore inboxes.
+3. If an agent already exists in the fresh team, use `SendMessage` rather than spawning a duplicate.
+4. Always spawn agents with `run_in_background: true` and the required `name` and `team_name` parameters.
+5. Always use the agent's roster prompt (read from `.claude/teams/esmuseum/prompts/<name>.md`, or `.claude/teams/prompts/<name>.md` for shared prompts like tervis) and append the task description — do not write a fresh prompt.
+
+## Role boundaries (Lead)
+
+You are a **coordinator**, not an implementer. See `prompts/lead.md` for the full tool restrictions. Short version:
+
+- **Read:** ONLY team config, memory files, CLAUDE.md, roster, common-prompt.
+- **Write:** ONLY files under `.claude/teams/esmuseum/memory/`.
+- **Bash:** ONLY `date`, `git pull`, `git status`, `git log`.
+- **NEVER** read or edit `.ts` / `.vue` / `.js` source — delegate to Finn (research) or the relevant specialist.
+- **NEVER** run `npm test`, `npm run build`, `npm run lint`, or `git add/commit/push` — those belong to the implementer on the task.
+
+## Roster quick-reference
+
+| Name   | Model   | Color   | Role                                       |
+| ------ | ------- | ------- | ------------------------------------------ |
+| lead   | Opus    | —       | coordinator (you, main session)            |
+| viiu   | Sonnet  | green   | frontend (Vue / Nuxt / Tailwind / Naive)   |
+| entu   | Sonnet  | yellow  | backend / Entu API / webhooks / OAuth      |
+| kaarel | Sonnet  | cyan    | map / Leaflet / geolocation                |
+| tess   | Sonnet  | purple  | testing (Vitest / unit / api / composables)|
+| marcus | Opus    | blue    | code review (RED / YELLOW / GREEN)         |
+| finn   | Haiku   | black   | research / codebase lookups / issue reads  |
+| tervis | Opus    | magenta | health audit (shared prompt, spawned FIRST)|
+
+(*ESM:Lead*)

--- a/.claude/teams/esmuseum/memory/entu.md
+++ b/.claude/teams/esmuseum/memory/entu.md
@@ -52,6 +52,148 @@
 - 5 lines of `data.entity?.email?.[0]?.string || ''` = 15 optional chains + 5 fallbacks = 20 branches alone
 - Fix: extract a helper like `getEntityString(prop)` that takes the array and returns `prop?.[0]?.string ?? ''`
 
+## Session 2026-04-20
+
+### [LEARNED] Admin key (ENTU_ADMIN_KEY) scope and capabilities (2026-04-20)
+
+- Key lives in `.env.admin` as `ENTU_ADMIN_KEY` (NOT `NUXT_ENTU_ADMIN_KEY` — Eli's naming)
+- Belongs to **Mihkel Putrinš** (person entity `66b6245c7efc9ac06a437b97`, account `esmuuseum`)
+- JWT: has `accounts.esmuuseum` user claim — authenticated, NOT anonymous
+- Same IP restriction as manager key: `aud: 82.131.122.238`, ~48h expiry
+- **Write capabilities (all confirmed by test)**:
+  - Create entities: YES — but `_type` must use `reference` (ID), NOT `string`
+  - `folder` type reference ID: `66b624597efc9ac06a4378a6`
+  - Set `_sharing` (domain/public/private): YES
+  - Add `_viewer`/`_expander`/`_editor` references: YES
+  - Delete entities: YES (`DELETE /api/{account}/entity/{id}` → `{"deleted":true}`)
+  - Delete individual properties: YES — `DELETE /api/{account}/property/{propId}` → `{"deleted": true}` (confirmed working, removes the specific property value)
+- **Important**: omitting `_id` in POST = ADD new property; include `_id` to OVERWRITE existing
+- Mihkel is `_owner` on all VR entities (vr_kavaler, vr_aum2rk) → can modify their rights
+- **Issue #42 (Juhendid folder)**: FULLY SCRIPTABLE — create folder, set `_sharing: "domain"`
+- **Issue #41 (VR restriction)**: FULLY SCRIPTABLE — Mihkel is owner, can change `_sharing` + add `_viewer`
+- Entity type IDs (for `_type` reference): folder=66b624597efc9ac06a4378a6, grupp=686914521749f351b9c82f35, ulesanne=686917231749f351b9c82f4c, vastus=686917401749f351b9c82f58, asukoht=687d27c9259fc48ba59cf726, kaart=687d27c8259fc48ba59cf71a, **link=69e65f5f2cd89347a7f383e5** (recreated 2026-04-20; previous `69e64a3c2cd89347a7f382af` deleted)
+- Property type meta-ID (for defining properties of a type): `66b6245a7efc9ac06a437a42`
+- Database root entity (account parent): `66b6245c7efc9ac06a437ba0`
+
+### [LEARNED] Entu entity type creation quirk (2026-04-20)
+
+- Creating a type definition entity WITH `_parent: <db-root>` → `400 "User not in parent _owner, _editor nor _expander property"` even though Mihkel's `_parent_expander` includes the DB root — check is on DIRECT rights, not inherited
+- Creating WITHOUT `_parent` → succeeds; Entu places entity at root level; functionally equivalent for type usage
+- Subsequent POST to add `_parent` to the parentless entity → same 400 error
+- `url` IS a valid Entu property type (accepted by API, even though unused in account before this)
+- Property types in this account: string, text, number, boolean, reference, file, date, datetime, url
+
+### [LEARNED] link entity type (2026-04-20)
+
+- `link` type entity ID: `69e64a3c2cd89347a7f382af`
+- `title` property def ID: `69e64a592cd89347a7f382bb` (type: string, ordinal 1, search: true)
+- `url` property def ID: `69e64a592cd89347a7f382c8` (type: url, ordinal 2, search: false)
+- Tested: link entity created under a folder, title + url both store correctly, `_type: link` confirmed
+- Juhendid folder _id: `69e64b1f2cd89347a7f382e6` (_sharing: domain, no _parent — root level)
+- Link 1 "Loo uus grupp ja kutsu õpilased" _id: `69e64b332cd89347a7f382ed`
+- Link 2 "KML-failide import Entusse" _id: `69e64b332cd89347a7f382f6`
+- Eli Pilve person entity: `66d97072f2daf46b3145403c` (eli.pilve@esm.ee) — needed for _expander grant on Juhendid
+- Kasutusjuhendid menu _id: `69e64cae2cd89347a7f38300` (group=Kaardirakendus, query filters link+parent=Juhendid)
+
+### [LEARNED] NUXT_ENTU_MANAGER_KEY scope (2026-04-20)
+
+- Active server key is `NUXT_ENTU_MANAGER_KEY` — NOT `NUXT_ENTU_KEY` (latter is defined in nuxt.config but unused and unset in .env)
+- JWT audience is IP-restricted to `82.131.122.238` (production server IP)
+- **Scope: read-only, VR data only** — sees ~3,116 `vr_kavaler` and ~3,236 `vr_aum2rk` entities
+- Sees 0 of: `ülesanne`, `vastus`, `asukoht`, `kaart`, `grupp`, `person`, `folder`
+- Any write attempt (create entity, modify permissions) → `403 "No user"` — key has no Entu user identity
+- VR entities are `_sharing: "public"` so the key reads them as a public reader, not an authenticated user
+- Confirmed: neither #41 (restrict VR entity types) nor #42 (create "Juhendid" folder) can be automated with this key
+- Both require admin escalation: Entu UI is the lowest-effort path (Mihkel or Eli clicks in entu.app)
+
+### [GOTCHA] ENTU_ADMIN_KEY auto-assigns Mihkel as `_owner` on creation (2026-04-20)
+
+- Entities created via ENTU_ADMIN_KEY get explicit `_owner: Mihkel` property automatically
+- Historic Entu entities (pre-dating the key) have NO explicit `_owner` property — they rely on account-level inheritance; Entu UI shows Mihkel because he's account admin, not via property
+- New entities (created with key): API returns full `_owner/editor/expander/viewer` derived from one `_owner` property record
+- Historic entities: API returns only `_sharing`, no `_owner` in response
+- **Do NOT need to manually add `_owner` on creation** — the key handles it
+- Eli's UI "not owner" report (2026-04-20) was a false alarm: all 8 new entities confirmed `_owner=66b6245c7efc9ac06a437b97` via API
+
+### [LEARNED] link `name` formula property (2026-04-20)
+
+- Property def `_id`: `69e64de22cd89347a7f3830b`
+- `_parent: 69e64a3c2cd89347a7f382af` (link type), `_type: property`
+- `formula: "'[' title '](' url ')'"` — space-separated CONCAT with single-quoted literals
+- `markdown: true` (`_id: 69e6501e2cd89347a7f3831c`) added separately — renders output as clickable markdown
+- Both existing links verified computing correctly after entity touch
+- Formula reference model: `person.name` = `forename ' ' surname`
+
+### [REPORT] Raw ownership dump (2026-04-20)
+
+All new entities — `_owner` verbatim (reference `66b6245c7efc9ac06a437b97` = Mihkel Putrinš, property_type `_owner`):
+- link-type `69e64a3c2cd89347a7f382af`: `_owner._id=69e64a3c2cd89347a7f382b4` ✓
+- prop-title `69e64a592cd89347a7f382bb`: `_owner._id=69e64a592cd89347a7f382c6` ✓
+- prop-url `69e64a592cd89347a7f382c8`: `_owner._id=69e64a592cd89347a7f382d3` ✓
+- prop-name-formula `69e64de22cd89347a7f3830b`: `_owner._id=69e64de22cd89347a7f38317` ✓
+- juhendid-folder `69e64b1f2cd89347a7f382e6`: `_owner._id=69e64b1f2cd89347a7f382eb` ✓
+- link-1 `69e64b332cd89347a7f382ed`: `_owner._id=69e64b332cd89347a7f382f4` ✓
+- link-2 `69e64b332cd89347a7f382f6`: `_owner._id=69e64b332cd89347a7f382fd` ✓
+- menu `69e64cae2cd89347a7f38300`: `_owner._id=69e64caf2cd89347a7f38309` ✓
+
+Historic control (`66b6245a7efc9ac06a437920`): `_owner` KEY_MISSING — no explicit owner property.
+
+No `inherited` flag in any entry. Behavioral test (add `_viewer: Eli` on link type) → **succeeded** (`_id: 69e654242cd89347a7f38320`, then deleted). Mihkel is confirmed effective owner via direct `_owner` property.
+
+### [REPORT] Property diff: historic vs new link type (2026-04-20)
+
+**Historic `66b6245a7efc9ac06a437920` keys:** `_id`, `_parent`→DB_ROOT, `_sharing:domain`, `_type:entity`, `add_from`×2, `default_parent`, `label`×2, `label_plural`×2, `name`, `plugin`×3
+- NO `_owner`, `_editor`, `_expander`, `_viewer`, `_inheritrights`, `_created`
+
+**New link type `69e64a3c2cd89347a7f382af` keys:** `_id`, `_sharing:domain`, `_type:entity`, `_owner`×2 (Mihkel+Eli), `_editor`×2 (derived+direct), `_expander`×2 (derived), `_viewer`×2 (derived), `_inheritrights:true`, `_created`, `_reference`, `add_from`, `label`×2, `label_plural`×2, `name`
+- Missing vs historic: `_parent`, `plugin`, `default_parent`
+
+**Key finding:** Historic rights come from `_parent→DB_ROOT` cascade (no explicit rights). New entity rights are explicit but `_editor`/`_expander`/`_viewer` initially showed `property_type: "_owner"` (derived), NOT `property_type: "_editor"` (direct). Added direct `_editor: Mihkel` (`_id: 69e655df2cd89347a7f38324`) — now shows `property_type: "_editor"`. Waiting for Eli to confirm if UI edit now works.
+
+**[REPORT] _editor + _expander verbatim on link type `69e64a3c2cd89347a7f382af`:**
+
+`_editor`:
+- `{_id: "69e655df2cd89347a7f38324", reference: "66b6245c7efc9ac06a437b97", property_type: "_editor", string: "Mihkel Putrinš", entity_type: "person"}` ← DIRECT
+- `{_id: "69e655062cd89347a7f38323", reference: "66d97072f2daf46b3145403c", property_type: "_owner", string: "Eli Pilve", entity_type: "person"}` ← derived from _owner
+
+`_expander`:
+- `{_id: "69e6560f2cd89347a7f38325", reference: "66b6245c7efc9ac06a437b97", property_type: "_expander", string: "Mihkel Putrinš", entity_type: "person"}` ← DIRECT
+- `{_id: "69e655062cd89347a7f38323", reference: "66d97072f2daf46b3145403c", property_type: "_owner", string: "Eli Pilve", entity_type: "person"}` ← derived from _owner
+
+Historic `66b6245a7efc9ac06a437920`: `_editor` KEY_MISSING, `_expander` KEY_MISSING — all rights inherited via `_parent → DB_ROOT`.
+
+Both Mihkel entries: `reference: "66b6245c7efc9ac06a437b97"` (Mihkel's person ID). Entry IDs differ: `_editor._id=69e655df2cd89347a7f38324`, `_expander._id=69e6560f2cd89347a7f38325`.
+
+**[GOTCHA] Derived vs direct rights display:** When `_editor` shows `property_type: "_owner"`, that means the edit right is derived from `_owner` status. Adding explicit `_editor` creates a separate property with `property_type: "_editor"`. Entu deduplicates — only one entry per person in each computed slot.
+
+### [GOTCHA] `_parent: DB_ROOT` blocked by API for all users (2026-04-20)
+
+- DB_ROOT (`66b6245c7efc9ac06a437ba0`) has NO explicit `_owner`/`_editor`/`_expander` properties
+- Entu API check: "User not in parent _owner, _editor nor _expander property" → fails for every user via API
+- Historic entities that ARE parented to DB_ROOT were created via superadmin/UI path that bypasses this check
+- **Workaround**: Mihkel must set `_parent` via Entu UI for entities that need to be under DB_ROOT
+- **Precedent**: "Kaardid" menu (`687c9fd8259fc48ba59cf2e4`) and all root folders also have no `_parent` and function fine
+
+---
+
+## [REPORT] Session 2026-04-20 outcomes
+
+### Formula property on `link` type
+- Property def `_id`: `69e64de22cd89347a7f3830b`
+- Formula: `'[' title '](' url ')'` (CONCAT with literal brackets, modelled on `person.name`)
+- `markdown: true` property `_id`: `69e6501e2cd89347a7f3831c`
+- Link 1 (`69e64b332cd89347a7f382ed`) verified: `[Loo uus grupp ja kutsu õpilased](https://scribehow.com/embed-preview/ESM_Kaardirakendus_Loo_uus_grupp_ja_kutsu_opilased__KJsMWqnkT-SGhlAjqwuIdA)` ✓
+- Link 2 (`69e64b332cd89347a7f382f6`) verified: `[KML-failide import Entusse](https://scribehow.com/embed-preview/KML_failide_import_Entusse__Q2sbaiS9R8eUaa-zbPQPTw)` ✓
+
+### Ownership investigation
+- All 8 new entities have explicit `_owner: Mihkel` set automatically by ENTU_ADMIN_KEY
+- Link 1 + 2: `_parent = Juhendid folder` ✓ (inherit from folder's Mihkel ownership)
+- Juhendid folder, link type, menu: root-level (no `_parent`) — API blocks `_parent: DB_ROOT`
+- **Action needed**: Mihkel to set `_parent` via Entu UI on:
+  - `link` type (`69e64a3c2cd89347a7f382af`) → DB_ROOT
+  - `Kasutusjuhendid` menu (`69e64cae2cd89347a7f38300`) → DB_ROOT
+  - Juhendid folder is consistent with other folders (all root-level) — may not need a parent
+
 ### [PATTERN] Webhook handler testing (2026-03-08)
 
 - Mock `h3` with `vi.mock('h3')` — override `defineEventHandler` (passthrough) and `readBody` (return `event._body`)

--- a/.claude/teams/esmuseum/memory/health-report.md
+++ b/.claude/teams/esmuseum/memory/health-report.md
@@ -1,250 +1,170 @@
-# Team Health Report — 2026-03-08
+# Team Health Report — 2026-04-20
 
 ## Summary
 
-- 19 recommendations total
-- 4 STALE, 4 PROMOTE, 3 GAP, 3 COMMON, 3 CONSOLIDATE, 2 CROSSPOLL
+- 12 recommendations total
+- 3 STALE, 2 PROMOTE, 2 CROSSPOLL, 2 GAP, 2 COMMON, 1 CONSOLIDATE
+
+## Previous Audit Follow-Up (from 2026-03-08)
+
+| Issue | Status |
+| ----- | ------ |
+| CLAUDE.md token-expiry "12h" → "48h" | **FIXED** ✓ — All 5 references now say "48h" / "JWT `exp` claim" |
+| MEMORY.md GitHub Issues section stale | **PARTIALLY FIXED** — Issues #31/#38/#39 listed correctly as CLOSED, but new problem below |
+| `~~/` import convention not in shared docs | **FIXED** ✓ — Now in common-prompt.md lines 77-80 |
+| MSW constraints not documented | **FIXED** ✓ — Now in common-prompt.md lines 85-91 AND Tess prompt lines 49-55 |
+| Roster model inconsistency (finn="haiku") | **FIXED** ✓ — Now uses full ID `claude-haiku-4-5-20251001` |
+| `readonly` global stub missing | **FIXED** ✓ — In setup-globals.ts, Tess scratchpad marked RESOLVED |
+| Tess `import.meta.client/dev` not in prompt | **FIXED** ✓ — Tess prompt lines 43-44 |
+| Lead prompt missing maintenance duties | **FIXED** ✓ — Lead prompt step 9 (MAINTAIN) now included |
+| Common-prompt `finn-*.md` stale reference | **FIXED** ✓ — Removed; finn reports are session-scoped |
+
+**9/9 flagged items from last audit were addressed.** Excellent maintenance.
+
+---
 
 ## Recommendations
 
----
+### [STALE] #1: MEMORY.md — "Kõik issue'd suletud" claim is false
 
-### [STALE] MEMORY.md: GitHub Issues section — 6 issues listed as OPEN are now CLOSED
-
-**Source**: MEMORY.md lines 79-88
-
-**Finding**: Issues #31, #32, #33, #34, #35, #36 are all listed as OPEN but GitHub shows them CLOSED. Issue #31 says "1/6 done" but all 6 sub-issues are resolved. Issue #35 says "25% → 60%" but coverage is now 74%+. Issue #38 (token expiry fix) and #39 (complexity) are not listed at all.
-
-**Recommendation**: Update the GitHub Issues section. Mark #31-#36 as CLOSED. Add #38 (CLOSED) and #39 (OPEN). Update #35 description to reflect actual coverage reached (74%).
-
-**Rationale**: Stale issue status causes wasted time checking GitHub to verify current state.
+**Source**: MEMORY.md line 82
+**Finding**: Claims "Kõik issue'd suletud (seisuga 2026-03-09)" but **issue #40** (Workflow improvements from Claude Code Insights analysis) has been OPEN since 2026-03-08 — 42 days with no progress.
+**Recommendation**: Update the line to: `- **#40**: Workflow improvements from Insights analysis — OPEN`; remove the "all closed" claim.
+**Rationale**: Misleading for any agent or session checking project status.
 
 ---
 
-### [STALE] CLAUDE.md: Token expiry still says "12-hour" in 3 places
+### [STALE] #2: Finn scratchpad — token expiry gotcha resolved
 
-**Source**: CLAUDE.md lines 94, 164, 250
-
-**Finding**: Issue #38 fixed token expiry to parse JWT `exp` claim instead of hardcoded 12h. Entu issues 48h tokens. But CLAUDE.md still says "12-hour expiry", "12h validity" in Authentication section.
-
-**Recommendation**: Update CLAUDE.md to say "token validity parsed from JWT `exp` claim (typically 48h)" instead of "12-hour expiry".
-
-**Rationale**: Misleading documentation causes debugging confusion. This was finn's `[GOTCHA]` — now fixed in code but not in docs.
+**Source**: finn.md line 19: `[GOTCHA] Our code sets 12h token expiry but Entu docs say 48h`
+**Finding**: Issue #38 fixed this 6 weeks ago. Code now parses JWT `exp` claim. The gotcha describes a bug that no longer exists.
+**Recommendation**: Remove this line from finn.md.
+**Rationale**: Actively misleading — suggests a live bug.
 
 ---
 
-### [STALE] Tess scratchpad: `readonly` not in global setup
+### [STALE] #3: Finn scratchpad — "0% real server coverage" outdated
 
-**Source**: tess.md lines 67-69
-
-**Finding**: Tess's `[GOTCHA]` says `readonly` is NOT in setup-globals.ts. But it HAS been added (setup-globals.ts line 37-39: `globalThis.readonly = readonly`). The gotcha is now resolved.
-
-**Recommendation**: Remove or mark as resolved in tess.md. Also update tess.md line 56 ("needs `vi.stubGlobal('readonly', readonly)` + resetModules") since it's now globally available.
-
-**Rationale**: Stale gotcha wastes agent time adding redundant stubs.
+**Source**: finn.md line 26: `[LEARNED] server/ has 15 files, 3149 lines total. 0% real coverage`
+**Finding**: Entu wrote 22 webhook handler tests (per entu.md checkpoint). Server coverage is no longer 0%.
+**Recommendation**: Remove or update this entry. The "best first targets" list (line 27) may still be partially useful but the "0%" claim is false.
+**Rationale**: Agents making prioritization decisions based on this will waste effort re-auditing.
 
 ---
 
-### [STALE] Common-prompt: "Finn stores detailed reports as `finn-<topic>.md`"
+### [PROMOTE] #1: Entu → common-prompt — ESLint optional chaining complexity
 
-**Source**: common-prompt.md line 88
-
-**Finding**: The old `finn-*.md` report files were in `.claude/teams/memory/` which was deleted during team directory restructuring. No `finn-*.md` files exist in the current `.claude/teams/esmuseum/memory/` directory.
-
-**Recommendation**: Either remove this line, or if the pattern should continue, note that reports are transient (session-scoped) and won't persist across team recreations.
-
-**Rationale**: References to non-existent files confuse agents looking for prior research.
-
----
-
-### [PROMOTE] Tess scratchpad → Tess prompt: MSW + resetModules pattern
-
-**Source**: tess.md lines 62-69, lines 75-77
-
-**Finding**: Tess's prompt already covers MSW constraints well (lines 48-53). However, the `import.meta.client`/`import.meta.dev` gotcha (line 75-77 in scratchpad) is important for future test writing and is NOT in the prompt.
-
-**Recommendation**: Add to tess.md prompt under "Nuxt Compile-Time Constants": note that `define` in vitest.config.ts sets these to `true`, and that after `vi.resetModules()`, globalThis mocks (including readonly) get cleared and need re-stubbing.
-
-**Rationale**: This was a repeated discovery — already partially promoted but the resetModules interaction was missed.
+**Source**: entu.md lines 49-52: `[LEARNED] ESLint counts optional chaining as complexity`
+**Finding**: `?.` counts as a cyclomatic complexity branch in ESLint. 5 lines of chaining = 20 branches. Non-obvious, affects ANY agent refactoring for complexity.
+**Recommendation**: Add to common-prompt.md (new "## Lint Notes" section or append to existing standards):
+```markdown
+- `?.` (optional chaining) counts as a cyclomatic branch in ESLint's `complexity` rule
+- Extract helpers like `getEntityString(prop)` to reduce branch counts in Entu property access
+```
+**Rationale**: useEntuAuth.ts still has complexity 24 (remaining from #39). Next refactoring attempt needs this knowledge. Currently only Entu knows it.
 
 ---
 
-### [PROMOTE] Kaarel scratchpad → Kaarel prompt: NormalizedLocation format
+### [PROMOTE] #2: Entu → Tess prompt — Webhook handler testing pattern
 
-**Source**: kaarel.md lines 54-60
-
-**Finding**: Kaarel's `[LEARNED]` about `getLocationCoordinates()` needing to check `location.coordinates` format (not just Entu raw) and the `[DECISION]` about null coordinates instead of (0,0) are important for future geo work. Kaarel's prompt mentions `location-transform.ts` but doesn't mention the NormalizedLocation format or the null-coordinates convention.
-
-**Recommendation**: Add to kaarel.md prompt under "Key Patterns": `NormalizedLocation.coordinates` can be `null` (no map marker shown). Distance calculations handle this gracefully.
-
-**Rationale**: Prevents re-introducing the Infinity km bug pattern.
-
----
-
-### [PROMOTE] Entu scratchpad → Entu prompt: EntityData is array, not object
-
-**Source**: entu.md lines 23-27
-
-**Finding**: Entu learned that `createEntity`/`updateEntity` receive `EntuPropertyUpdate[]` (array), NOT an object. This is a non-obvious API detail that's easy to get wrong. Not in the prompt.
-
-**Recommendation**: Add to entu.md prompt under "Key Patterns": `createEntity`/`updateEntity` take `EntuPropertyUpdate[]` array format, not object format.
-
-**Rationale**: Both entu and test writers hit this — saves re-discovery time.
+**Source**: entu.md lines 56-60: `[PATTERN] Webhook handler testing`
+**Finding**: Detailed mock pattern for h3, entu-admin, webhook-queue. Tess is the test engineer but this pattern exists only in Entu's scratchpad.
+**Recommendation**: Add to Tess prompt under a new section "## Server/Webhook Test Patterns":
+```markdown
+- Mock `h3` with `vi.mock('h3')` — override `defineEventHandler` (passthrough) and `readBody` (return `event._body`)
+- Mock `entu-admin`, `webhook-queue`, `logger` at module level
+- Use `installNuxtMocks()` for createError, getHeader
+- Event shape: `{ _headers, _query, _body, _cookies, context: { params }, node: { req, res } }`
+```
+**Rationale**: Next time Tess writes webhook tests, she won't need to ask Entu or rediscover this.
 
 ---
 
-### [PROMOTE] Marcus scratchpad → Marcus prompt: Review technique for lint comparison
+### [CROSSPOLL] #1: Kaarel's Infinity km bug — shared boundary awareness
 
-**Source**: marcus.md line 13
-
-**Finding**: `git stash && lint && stash pop` technique for comparing warning counts before/after is a reusable review strategy. Not in the prompt.
-
-**Recommendation**: Add to marcus.md prompt under "Review Process": use `git stash && npm run lint && git stash pop` to compare pre-existing warnings vs introduced.
-
-**Rationale**: Actionable technique that improves review quality.
+**Source**: kaarel.md lines 56-58
+**Finding**: The fix touched `distance.js` which sits at the boundary between Kaarel's domain (geo/coordinates) and the general data pipeline. `distance.js` is also still plain JavaScript (not TypeScript).
+**Recommendation**: Note for lead awareness only — no prompt change needed. If location data model changes, coordinate between Kaarel and Entu. Consider converting `distance.js` → `distance.ts` (see [GAP] #1).
 
 ---
 
-### [GAP] Lead prompt: No guidance on CLAUDE.md maintenance
-
-**Source**: Lead prompt (lead.md)
-
-**Finding**: Lead is the natural owner of CLAUDE.md accuracy. The prompt has no mention of verifying/updating CLAUDE.md when issues are resolved (e.g., token expiry fix in #38 didn't update CLAUDE.md). The lead should ensure CLAUDE.md stays current after significant changes.
-
-**Recommendation**: Add to lead.md: "After closing significant issues, verify CLAUDE.md is still accurate. Delegate to Finn to check if documentation references are stale."
-
-**Rationale**: CLAUDE.md is the project's primary knowledge source. Stale entries multiply confusion.
-
----
-
-### [GAP] Lead prompt: No MEMORY.md maintenance guidance
-
-**Source**: Lead prompt (lead.md)
-
-**Finding**: Lead's prompt says nothing about maintaining MEMORY.md (the auto-memory file). MEMORY.md has a GitHub Issues section that went stale because nobody owns updating it. The lead should update MEMORY.md issue status when closing issues.
-
-**Recommendation**: Add to lead.md: "After closing GitHub issues, update MEMORY.md's GitHub Issues section."
-
-**Rationale**: MEMORY.md is loaded into every conversation. Stale issue status wastes context tokens and causes confusion.
-
----
-
-### [GAP] Common-prompt: No guidance on test file location conventions
-
-**Source**: Multiple scratchpads
-
-**Finding**: Common-prompt has "Import Paths" section with `~/` and `~~/` conventions, and "Testing Notes" section. But there's no mention of WHERE test files go relative to what they test. The directory structure is `tests/unit/`, `tests/composables/`, `tests/component/`, `tests/api/`, `tests/integration/` — this is only documented in CLAUDE.md, not common-prompt. Agents creating test files need to know which directory to use.
-
-**Recommendation**: Add a brief note to common-prompt Testing Notes: test file location conventions (unit/ for utils, composables/ for composables, component/ for component logic, api/ for server endpoints).
-
-**Rationale**: Tess and other agents creating tests need this; currently they must check CLAUDE.md.
-
----
-
-### [CONSOLIDATE] `~~/` import convention — noted by 3+ agents independently
-
-**Source**: kaarel.md line 21, viiu.md lines 5, 11, entu.md (implicit in import fixes), tess.md line 33
-
-**Finding**: The double-tilde `~~/` convention for project root imports was independently discovered by Kaarel, Viiu, and Tess. It IS documented in common-prompt.md (line 77-79). However, the specific case of `types/` being at project root (requiring `~~/types/`) keeps getting re-discovered.
-
-**Recommendation**: Strengthen common-prompt.md Import Paths section: explicitly list `types/` and root `utils/` as requiring `~~/`. Example: `import { NormalizedLocation } from '~~/types/location'`.
-
-**Rationale**: Despite being documented, the current wording isn't prominent enough to prevent re-discovery.
-
----
-
-### [CONSOLIDATE] Node test environment has no DOM — repeated across agents
-
-**Source**: kaarel.md line 49, viiu.md line 31, tess.md lines 3-6
-
-**Finding**: Three agents independently discovered that vitest runs in `node` env (no DOM, no document, no window). Each found workarounds. This IS in common-prompt (line 83) but terse: "Vitest env is `node` — no DOM, no `document`, no `window`".
-
-**Recommendation**: Expand common-prompt Testing Notes to add: "Component tests must be logic-focused (exported functions, computed behavior). Use plain object stubs for DOM elements. No mount/render without adding happy-dom."
-
-**Rationale**: The current one-liner doesn't convey the practical implications that agents keep re-discovering.
-
----
-
-### [CONSOLIDATE] Singleton composable testing pattern — discovered by Kaarel and Tess
-
-**Source**: kaarel.md lines 41-47, tess.md lines 56-58
-
-**Finding**: Both Kaarel and Tess documented the `vi.resetModules()` + re-import pattern for singleton composables. This IS in common-prompt (lines 85-87) but should be strengthened.
-
-**Recommendation**: Common-prompt already covers this adequately. No change needed — this is a false consolidation candidate.
-
-**Rationale**: N/A (withdrawn after review).
-
----
-
-### [COMMON] CLAUDE.md references need cross-checking after issue closure
-
-**Source**: CLAUDE.md token expiry stale entries
-
-**Finding**: When issues resolve code changes, nobody updates CLAUDE.md. This is a process gap, not a knowledge gap. The team needs a convention: "when closing an issue that changes documented behavior, check CLAUDE.md."
-
-**Recommendation**: Add to common-prompt: "After closing issues that change documented behavior, verify CLAUDE.md references are still accurate. Report stale entries to lead."
-
-**Rationale**: Prevents documentation rot. CLAUDE.md is the project's single source of truth.
-
----
-
-### [COMMON] Roster model field: "haiku" vs full model ID
-
-**Source**: roster.json line 49
-
-**Finding**: Finn's model is listed as `"haiku"` while all other agents use full model IDs (`"claude-sonnet-4-6"`, `"claude-opus-4-6"`). This inconsistency could cause spawning issues if the Agent tool requires the full model ID.
-
-**Recommendation**: Standardize to `"claude-haiku-4-5-20251001"` or verify that `"haiku"` is accepted by the Agent tool.
-
-**Rationale**: Prevents spawning failures due to model ID resolution.
-
----
-
-### [COMMON] Lead prompt: session startup procedure references old directory structure
-
-**Source**: lead.md lines 9-10
-
-**Finding**: Lead prompt says "Create a fresh team: `TeamCreate(team_name="esmuseum")`" without the full backup/restore procedure. The detailed procedure IS in MEMORY.md (lines 38-43) and global CLAUDE.md. But the lead prompt itself is terse — it should at least reference where the full procedure lives.
-
-**Recommendation**: Add to lead.md step 2: "(see global CLAUDE.md for full backup/restore procedure)" or inline the critical steps.
-
-**Rationale**: Lead following only their prompt might skip the inbox backup/restore step.
-
----
-
-### [CROSSPOLL] Viiu's `useEntuAuth.refreshToken()` is synchronous — affects Entu's domain
+### [CROSSPOLL] #2: Viiu's refreshToken sync discovery → already in Entu prompt ✓
 
 **Source**: viiu.md line 9
-
-**Finding**: Viiu discovered that `refreshToken()` is synchronous (not async). This is relevant for Entu agent who owns auth logic in `server/utils/auth.ts` and might assume it's async.
-
-**Recommendation**: Add note to entu.md prompt or scratchpad: "Note: `useEntuAuth.refreshToken()` is synchronous — interface must match."
-
-**Rationale**: Cross-domain knowledge that could cause bugs if Entu modifies auth code.
+**Finding**: Already cross-pollinated — Entu prompt line 31 says `useEntuAuth.refreshToken() is synchronous — not async`. No action needed.
+**Status**: Resolved since last audit.
 
 ---
 
-### [CROSSPOLL] Finn's Entu API research — partially in CLAUDE.md but some gaps
+### [GAP] #1: No guidance on legacy .js files
 
-**Source**: finn.md lines 3-22
-
-**Finding**: Finn gathered comprehensive Entu API facts. Most were added to CLAUDE.md (token expiry, webhook token, signed URLs, default limit, property update). But some aren't: entity history endpoint (`GET /entity/{id}/history`), aggregate endpoint, `counter` property type, `_sharing` replacing `_public`, passkey/WebAuthn auth, property deletion being per-value-_id.
-
-**Recommendation**: Promote the most useful ones to CLAUDE.md "Entu API Key Facts" section: property deletion per-value-_id, entity history endpoint.
-
-**Rationale**: These are non-obvious API behaviors that could save debugging time.
+**Finding**: `app/utils/distance.js` and `app/utils/location-sync.js` remain as plain JavaScript. No documentation or prompt mentions these as known legacy or migration targets.
+**Recommendation**: Either (a) add a note to CLAUDE.md architecture section acknowledging these as known legacy JS, or (b) create a task to convert them to TypeScript with proper types.
+**Rationale**: Any agent encountering these may waste tokens deciding whether to convert them or not.
 
 ---
 
-## Meta-Observations
+### [GAP] #2: Issue #40 stale — no ownership
 
-1. **MEMORY.md is the biggest staleness risk** — it's loaded into every conversation but has no maintenance owner. The GitHub Issues section is fully out of date.
+**Finding**: Issue #40 (Workflow improvements from Claude Code Insights analysis) opened 2026-03-08, still OPEN after 42 days. Not referenced in any scratchpad. No assignee.
+**Recommendation**: Lead should triage: assign, schedule, or close as won't-fix.
+**Rationale**: Unowned open issues create ambiguity about project priorities.
 
-2. **CLAUDE.md has 3 stale token expiry references** — this is the most impactful fix since CLAUDE.md is the primary project reference.
+---
 
-3. **Scratchpads are generally healthy** — most entries are dated, tagged, and relevant. The main issue is completed gotchas that should be pruned.
+### [COMMON] #1: Scratchpad pruning trigger
 
-4. **Common-prompt is solid** — minor strengthening of Import Paths and Testing Notes sections would prevent recurring re-discoveries.
+**Finding**: Tess scratchpad = 93 lines (limit = 100). Contains a resolved `[GOTCHA]` that's already been struck through and old checkpoints that could be condensed.
+**Recommendation**: Add to common-prompt Shutdown Protocol:
+```markdown
+### Pruning
+If your scratchpad exceeds 70 lines before shutdown: remove resolved [GOTCHA] entries,
+collapse old [CHECKPOINT]s into a one-line summary, delete anything now in common-prompt or your prompt.
+```
+**Rationale**: Proactive pruning prevents hitting the 100-line limit mid-session.
 
-5. **Lead prompt is minimal but functional** — the two gaps (CLAUDE.md maintenance, MEMORY.md maintenance) are process issues that could be addressed with 2-3 lines.
+---
+
+### [COMMON] #2: Scratchpad date format not standardized
+
+**Finding**: Inconsistent formats:
+- Finn: `## Heading (YYYY-MM-DD)` with `[TAG]` inline
+- Tess/Kaarel: `## [TAG] YYYY-MM-DD — title`
+- Marcus: `## YYYY-MM-DD` (section heading, entries below)
+
+Common-prompt says "date every entry" but doesn't specify format.
+**Recommendation**: Add to common-prompt memory tags table header:
+```markdown
+Entry format: `## [TAG] YYYY-MM-DD — short title`
+```
+**Rationale**: Consistent format makes auditing and staleness detection easier.
+
+---
+
+### [CONSOLIDATE] #1: "No DOM testing" — duplicated in 3 scratchpads
+
+**Source**: viiu.md line 31, kaarel.md line 49, tess.md lines 3-6
+**Finding**: All three independently note "vitest env = node, no DOM". This is already in common-prompt line 85. Scratchpad entries add nothing beyond what's documented.
+**Recommendation**: Viiu and Kaarel can prune their "no DOM" entries during next pruning cycle. Only Kaarel's specific HTMLElement stub workaround adds unique value.
+**Rationale**: Saves scratchpad space. Single source of truth exists in common-prompt.
+
+---
+
+## Scratchpad Health
+
+| Agent | Lines | Health | Action |
+| ----- | ----- | ------ | ------ |
+| finn | 55 | 2 stale entries | Prune lines 19, 26 |
+| tess | 93 | **Near limit** | Prune resolved GOTCHA, condense old checkpoints |
+| kaarel | 76 | OK | Minor: remove "no DOM" duplication |
+| entu | 60 | Healthy | Promote webhook pattern, then can prune it |
+| viiu | 41 | Healthy | Minor: remove "no DOM" note |
+| marcus | 15 | Healthy | No action |
+
+## Priority Order for Lead
+
+1. **MEMORY.md #40 claim** — 30-second fix, currently false statement about project state
+2. **Finn stale token gotcha** — actively misleading, describes a non-existent bug
+3. **Promote ESLint chaining to common-prompt** — prevents wasted tokens on next complexity refactor
+4. **Promote webhook test pattern to Tess prompt** — saves significant rediscovery cost
+5. **Triage issue #40** — 42 days unowned, decide: do it, assign it, or close it

--- a/.claude/teams/esmuseum/memory/tervis.md
+++ b/.claude/teams/esmuseum/memory/tervis.md
@@ -1,35 +1,21 @@
 # Tervis Scratchpad
 
-## [CHECKPOINT] 2026-03-08 — First audit completed
+## [CHECKPOINT] 2026-04-20 — Third audit completed
 
-Audited 6 scratchpads (finn, marcus, viiu, kaarel, entu, tess) + 3 supplementary finn reports.
-Cross-referenced against roster prompts, common-prompt, CLAUDE.md, and source code.
+Audited 6 scratchpads + lead prompt + common-prompt + CLAUDE.md + MEMORY.md.
+Cross-referenced against source code (useEntuAuth.ts, setup-globals.ts, distance.js, vitest.config.ts) and GitHub issues.
 
-18 recommendations: 3 PROMOTE, 3 CONSOLIDATE, 2 CROSSPOLL, 4 STALE, 3 GAP, 3 COMMON.
+12 recommendations: 3 STALE, 2 PROMOTE, 2 CROSSPOLL, 2 GAP, 2 COMMON, 1 CONSOLIDATE.
 
 Key findings:
-
-- `~~/` import convention noted by 3 agents independently — not in any shared doc
-- MSW constraints hit 3+ agents — biggest gap in test prompts
-- nuxt-icons removal made 3 scratchpad entries stale
-- Token expiry fix (#38) resolved finn's gotcha
-- `readonly` global stub missing — recurring issue
-
-Report: `.claude/teams/esmuseum/memory/health-report.md`
-
-## [CHECKPOINT] 2026-03-08 — Second audit (lead/MEMORY/common focus)
-
-Audited lead prompt, MEMORY.md, common-prompt.md, and all scratchpads against current project state.
-
-19 recommendations: 4 STALE, 4 PROMOTE, 3 GAP, 3 COMMON, 3 CONSOLIDATE, 2 CROSSPOLL.
-
-Top findings:
-
-- **MEMORY.md GitHub Issues section fully stale** — 6 issues listed OPEN are CLOSED, 2 new issues missing
-- **CLAUDE.md token expiry wrong in 3 places** — still says "12h" after #38 fixed it to JWT `exp` (48h)
-- **Tess `readonly` gotcha resolved** — setup-globals.ts now has it, scratchpad still warns
-- **Lead prompt missing maintenance duties** — no guidance on keeping CLAUDE.md/MEMORY.md current
-- **Roster model inconsistency** — finn uses "haiku" while others use full model IDs
+- Previous audit's 9 flagged items ALL fixed — excellent maintenance
+- MEMORY.md has new false claim (#40 is OPEN, not "all closed")
+- Finn's token-expiry gotcha still lingers (describes fixed bug)
+- Finn's "0% server coverage" also outdated (entu wrote 22 tests)
+- Tess scratchpad at 93/100 lines — needs pruning
+- ESLint optional-chaining complexity pattern deserves promotion to common-prompt
+- Webhook test pattern (entu) should be in Tess's prompt
+- Two legacy .js files (distance.js, location-sync.js) undocumented
 
 Report: `.claude/teams/esmuseum/memory/health-report.md`
 

--- a/.claude/teams/esmuseum/spawn_member.sh
+++ b/.claude/teams/esmuseum/spawn_member.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# spawn_member.sh — Spawn an esmuseum agent into an existing tmux pane.
+# Adapted from the bioforge-dev / entu-research pattern.
+#
+# Usage:
+#   spawn_member.sh [--target-pane %XX] <agent-name> [tmux-session]
+#
+# With --target-pane: spawn into that specific tmux pane ID.
+# Without:            look up the pane whose title matches <agent-name>
+#                     (pane titles are set by tmux-layout-engine from
+#                     .tmux-layout.yaml `panes.<name>.label`).
+#
+# Default session: esmuseum
+#
+# Preconditions:
+#   1. `TeamCreate(team_name="esmuseum")` has been run by the team-lead
+#      (so ~/.claude/teams/esmuseum/config.json exists).
+#   2. The tmux session from .tmux-layout.yaml is up (`tmux-esmuseum`).
+#   3. The target pane is free (running a bare shell, not already claude).
+
+TEAM_NAME="esmuseum"
+TEAM_DIR_REL=".claude/teams/$TEAM_NAME"
+
+TARGET_PANE=""
+if [[ "${1:-}" == "--target-pane" ]]; then
+  TARGET_PANE="${2:?--target-pane requires a pane ID (e.g. %5)}"
+  shift 2
+fi
+
+AGENT_NAME="${1:?Usage: spawn_member.sh [--target-pane %XX] <agent-name> [tmux-session]}"
+TMUX_SESSION="${2:-$TEAM_NAME}"
+
+REPO="$(git rev-parse --show-toplevel)"
+TEAM_DIR_ABS="$REPO/$TEAM_DIR_REL"
+ROSTER="$TEAM_DIR_ABS/roster.json"
+STATE_DIR="$HOME/.claude/teams/$TEAM_NAME"
+CONFIG="$STATE_DIR/config.json"
+
+[[ -f "$CONFIG" ]] || { echo "ERROR: $CONFIG not found. Run TeamCreate(team_name=\"$TEAM_NAME\") first." >&2; exit 1; }
+[[ -f "$ROSTER" ]] || { echo "ERROR: $ROSTER not found." >&2; exit 1; }
+
+# Duplicate gate — hard stop.
+if jq -e ".members[]? | select(.name == \"$AGENT_NAME\")" "$CONFIG" >/dev/null 2>&1; then
+  echo "ERROR: $AGENT_NAME already registered in config.json. Use SendMessage instead." >&2
+  exit 1
+fi
+
+# Resolve target pane.
+if [[ -z "$TARGET_PANE" ]]; then
+  TARGET_PANE=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_id} #{pane_title}' 2>/dev/null \
+    | awk -v n="$AGENT_NAME" '$2==n {print $1; exit}')
+  [[ -n "$TARGET_PANE" ]] || {
+    echo "ERROR: no pane titled '$AGENT_NAME' in tmux session '$TMUX_SESSION'." >&2
+    echo "       Either start the session (\`tmux-$TEAM_NAME\`) or pass --target-pane %X." >&2
+    exit 1
+  }
+fi
+
+if ! tmux list-panes -t "$TMUX_SESSION" -F '#{pane_id}' 2>/dev/null | grep -q "^${TARGET_PANE}$"; then
+  echo "ERROR: Target pane $TARGET_PANE not found in session $TMUX_SESSION." >&2
+  exit 1
+fi
+
+# Read roster entry.
+ROSTER_ENTRY=$(jq -r ".members[] | select(.name == \"$AGENT_NAME\")" "$ROSTER")
+[[ -n "$ROSTER_ENTRY" ]] || { echo "ERROR: $AGENT_NAME not found in roster." >&2; exit 1; }
+
+MODEL=$(echo "$ROSTER_ENTRY" | jq -r '.model')
+COLOR=$(echo "$ROSTER_ENTRY" | jq -r '.color // "gray"')
+AGENT_TYPE=$(echo "$ROSTER_ENTRY" | jq -r '.agentType // "general-purpose"')
+PROMPT_REL=$(echo "$ROSTER_ENTRY" | jq -r '.prompt // ""')
+
+# Resolve prompt path relative to the team-config dir.
+# Handles both "prompts/viiu.md" and "../prompts/tervis.md" (shared prompt).
+PROMPT_FILE=""
+if [[ -n "$PROMPT_REL" ]]; then
+  CANDIDATE="$TEAM_DIR_ABS/$PROMPT_REL"
+  if [[ -f "$CANDIDATE" ]]; then
+    PROMPT_FILE="$(cd "$(dirname "$CANDIDATE")" && pwd)/$(basename "$CANDIDATE")"
+  fi
+fi
+
+LEAD_SESSION_ID=$(jq -r '.leadSessionId' "$CONFIG")
+
+# Build spawn script (avoids tmux send-keys quoting issues).
+SPAWN_SCRIPT=$(mktemp /tmp/spawn-cmd-XXXXXX.sh)
+{
+  echo '#!/usr/bin/env bash'
+  echo 'source ~/.bashrc 2>/dev/null || true'
+  if [[ -n "$PROMPT_FILE" ]]; then
+    # Substitute {TEAM_DIR} placeholder (used by shared prompts like tervis.md).
+    printf 'PROMPT="$(sed '\''s|{TEAM_DIR}|%s|g'\'' %q)"\n' "$TEAM_DIR_REL" "$PROMPT_FILE"
+  fi
+  printf 'exec claude --agent-id "%s" \\\n' "${AGENT_NAME}@${TEAM_NAME}"
+  printf '  --agent-name "%s" --team-name "%s" \\\n' "$AGENT_NAME" "$TEAM_NAME"
+  printf '  --agent-color "%s" --parent-session-id "%s" \\\n' "$COLOR" "$LEAD_SESSION_ID"
+  printf '  --agent-type general-purpose --model "%s"' "$MODEL"
+  if [[ -n "$PROMPT_FILE" ]]; then
+    printf ' \\\n  --append-system-prompt "$PROMPT"'
+  fi
+  printf ' \\\n  --dangerously-skip-permissions'
+  printf ' \\\n  "Read your prompt and scratchpad. Send team-lead an intro and stand by."'
+  echo
+} > "$SPAWN_SCRIPT"
+chmod +x "$SPAWN_SCRIPT"
+
+tmux send-keys -t "$TARGET_PANE" "bash $SPAWN_SCRIPT" Enter
+
+# Register the agent in config.json so SendMessage can route.
+TIMESTAMP=$(date +%s)000
+jq --arg name "$AGENT_NAME" \
+   --arg agentId "${AGENT_NAME}@${TEAM_NAME}" \
+   --arg agentType "$AGENT_TYPE" \
+   --arg model "$MODEL" \
+   --arg color "$COLOR" \
+   --arg paneId "$TARGET_PANE" \
+   --argjson joinedAt "$TIMESTAMP" \
+   '.members += [{
+     agentId: $agentId,
+     name: $name,
+     agentType: $agentType,
+     model: $model,
+     color: $color,
+     joinedAt: $joinedAt,
+     tmuxPaneId: $paneId,
+     backendType: "tmux",
+     cwd: "",
+     subscriptions: []
+   }]' "$CONFIG" > "${CONFIG}.tmp" && mv "${CONFIG}.tmp" "$CONFIG"
+
+echo "Spawned $AGENT_NAME in pane $TARGET_PANE (session $TMUX_SESSION)"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 NUXT_ENTU_KEY=
 # Entu API Configuration (used by webhooks and client-side auth)
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 
 # F020: Webhook security (optional - for validating webhook requests)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
-.env
+.env*
+!.env.example
 .nuxt
 .output
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 dist
 node_modules
 coverage
+.tmp
 
 # SSL certificates for local development
 *.pem

--- a/.tmux-layout.yaml
+++ b/.tmux-layout.yaml
@@ -1,0 +1,40 @@
+# esmuseum tmux layout — 8 panes.
+#
+#  +-----------+-----------+-----------+
+#  |   viiu    |  kaarel   |   tess    |   featured row (~30% height)
+#  +-----------+-----+-----+-----------+
+#  |                 | entu  | marcus  |
+#  |      lead       +-------+---------+
+#  |                 |tervis |  finn   |
+#  +-----------------+-------+---------+
+#
+# lead runs claude; others are bare shells.
+# Upgrade a pane later with, e.g.:
+#   command: "tail -F .claude/teams/esmuseum/memory/<name>.md"
+
+initial: viiu
+
+splits:
+  # separate top strip from bottom area (top 30%, bottom 70%)
+  - { from: viiu,   below: lead,    size: 70% }
+  # top row columns: viiu | kaarel | tess
+  - { from: viiu,   right: kaarel,  size: 67% }
+  - { from: kaarel, right: tess,    size: 50% }
+  # bottom: lead (left 50%) | 2x2 quadrant (right 50%)
+  - { from: lead,   right: entu,    size: 50% }
+  # 2x2 quadrant: split into top/bottom halves, then each into left/right
+  - { from: entu,   below: tervis,  size: 50% }
+  - { from: entu,   right: marcus,  size: 50% }
+  - { from: tervis, right: finn,    size: 50% }
+
+panes:
+  viiu:   { label: viiu }
+  kaarel: { label: kaarel }
+  tess:   { label: tess }
+  lead:   { label: lead, command: "claude --dangerously-skip-permissions --continue", send_after: "Read .claude/startup.md and execute the esmuseum team-lead startup procedure." }
+  entu:   { label: entu }
+  marcus: { label: marcus }
+  tervis: { label: tervis }
+  finn:   { label: finn }
+
+focus: lead

--- a/app/composables/useEntuApi.ts
+++ b/app/composables/useEntuApi.ts
@@ -165,7 +165,7 @@ export const useEntuApi = (): UseEntuApiReturn => {
 
   // Runtime configuration
   const config = useRuntimeConfig()
-  const apiUrl = computed(() => config.public.entuUrl as string || 'https://entu.app')
+  const apiUrl = computed(() => config.public.entuUrl as string || 'https://api.entu.app')
   const accountName = computed(() => config.public.entuAccount as string || 'esmuuseum')
 
   // API state
@@ -176,7 +176,7 @@ export const useEntuApi = (): UseEntuApiReturn => {
    * Get base API URL for the current account
    */
   const getApiBase = (): string => {
-    return `${apiUrl.value}/api/${accountName.value}`
+    return `${apiUrl.value}/${accountName.value}`
   }
 
   /**

--- a/app/composables/useEntuAuth.ts
+++ b/app/composables/useEntuAuth.ts
@@ -261,10 +261,10 @@ export const useEntuAuth = (): UseEntuAuthReturn => {
    * This ensures we have the latest user information including any name changes
    */
   const fetchFreshUserData = async (userId: string, jwtToken: string): Promise<EntuUser> => {
-    const apiUrl = config.public.entuUrl || 'https://entu.app'
+    const apiUrl = config.public.entuUrl || 'https://api.entu.app'
     const accountName = config.public.entuAccount || 'esmuuseum'
 
-    const response = await fetch(`${apiUrl}/api/${accountName}/entity/${userId}`, {
+    const response = await fetch(`${apiUrl}/${accountName}/entity/${userId}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${jwtToken}`,
@@ -286,9 +286,9 @@ export const useEntuAuth = (): UseEntuAuthReturn => {
    * Fetch auth response from Entu API
    */
   const fetchAuthResponse = async (oauthToken: string): Promise<EntuAuthResponse> => {
-    const apiUrl = config.public.entuUrl || 'https://entu.app'
+    const apiUrl = config.public.entuUrl || 'https://api.entu.app'
     const accountName = config.public.entuAccount || 'esmuuseum'
-    const url = `${apiUrl}/api/auth?account=${accountName}`
+    const url = `${apiUrl}/auth?account=${accountName}`
 
     const response = await fetch(url, {
       method: 'GET',

--- a/app/composables/useEntuOAuth.ts
+++ b/app/composables/useEntuOAuth.ts
@@ -117,7 +117,7 @@ export const useEntuOAuth = (): UseEntuOAuthReturn => {
       }
 
       // Build the authentication URL
-      const apiUrl = config.public.entuUrl as string || 'https://entu.app'
+      const apiUrl = config.public.entuUrl as string || 'https://api.entu.app'
       const accountName = config.public.entuAccount as string || 'esmuuseum'
 
       // Store the current URL to redirect back after auth
@@ -143,7 +143,7 @@ export const useEntuOAuth = (): UseEntuOAuthReturn => {
       // Build the OAuth URL with callback
       const callback = encodeURIComponent(callbackUrl.value || '')
       // Use the /api/auth/{provider} endpoint as per documentation
-      const authUrl = `${apiUrl}/api/auth/${provider}?account=${accountName}&next=${callback}`
+      const authUrl = `${apiUrl}/auth/${provider}?account=${accountName}&next=${callback}`
 
       // In client context, redirect to OAuth
       if (import.meta.client) {

--- a/app/utils/entu-client.ts
+++ b/app/utils/entu-client.ts
@@ -3,7 +3,7 @@
  * These functions call Entu API directly from the browser using user's JWT token
  */
 
-const ENTU_API_URL = 'https://entu.app/api/esmuuseum'
+const ENTU_API_URL = 'https://api.entu.app/esmuuseum'
 
 /**
  * Update user's forename and surname

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -192,13 +192,13 @@ export async function authenticateUser (event: H3Event): Promise<AuthenticatedUs
  */
 async function authenticateUserViaAPI (event: H3Event, token: string): Promise<AuthenticatedUser> {
   const config = useRuntimeConfig()
-  const apiUrl = config.public.entuUrl || 'https://entu.app'
+  const apiUrl = config.public.entuUrl || 'https://api.entu.app'
   const accountName = config.public.entuAccount || 'esmuuseum'
 
-  logger.debug('Calling Entu auth endpoint', { url: `${apiUrl}/api/${accountName}` })
+  logger.debug('Calling Entu auth endpoint', { url: `${apiUrl}/${accountName}` })
 
   // Call the same endpoint that client uses for auth verification
-  const response = await fetch(`${apiUrl}/api/${accountName}`, {
+  const response = await fetch(`${apiUrl}/${accountName}`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -210,7 +210,7 @@ async function authenticateUserViaAPI (event: H3Event, token: string): Promise<A
   logger.info('Entu auth API response', {
     status: response.status,
     statusText: response.statusText,
-    url: `${apiUrl}/api/${accountName}`
+    url: `${apiUrl}/${accountName}`
   })
 
   if (!response.ok) {
@@ -221,7 +221,7 @@ async function authenticateUserViaAPI (event: H3Event, token: string): Promise<A
       logger.error('Auth API error response body', {
         status: response.status,
         body: errorBody,
-        url: `${apiUrl}/api/${accountName}`
+        url: `${apiUrl}/${accountName}`
       })
     }
     catch (e) {

--- a/server/utils/entu-admin.ts
+++ b/server/utils/entu-admin.ts
@@ -25,7 +25,7 @@ export function getAdminApiConfig (
 ): EntuApiOptions {
   const config = useRuntimeConfig()
   // Use public config for consistency with client-side code
-  const apiUrl = config.public.entuUrl as string || 'https://entu.app'
+  const apiUrl = config.public.entuUrl as string || 'https://api.entu.app'
   const accountName = config.public.entuAccount as string || 'esmuuseum'
 
   if (!apiUrl || !accountName) {

--- a/server/utils/entu.ts
+++ b/server/utils/entu.ts
@@ -26,7 +26,7 @@ interface EntuProperty {
  * Make authenticated API call to Entu
  */
 export async function callEntuApi (endpoint: string, options: Partial<RequestInit> = {}, apiConfig: EntuApiOptions) {
-  const url = `${apiConfig.apiUrl}/api/${apiConfig.accountName}${endpoint}`
+  const url = `${apiConfig.apiUrl}/${apiConfig.accountName}${endpoint}`
 
   const requestOptions: RequestInit = {
     headers: {
@@ -192,7 +192,7 @@ export function getEntuApiConfig (token: string): EntuApiOptions {
 
   return {
     token,
-    apiUrl: (config.entuApiUrl as string) || 'https://entu.app',
+    apiUrl: (config.public.entuUrl as string) || 'https://api.entu.app',
     accountName: (config.entuClientId as string) || 'esmuuseum'
   }
 }
@@ -203,10 +203,10 @@ export function getEntuApiConfig (token: string): EntuApiOptions {
  */
 export async function exchangeApiKeyForToken (apiKey: string): Promise<string> {
   const config = useRuntimeConfig()
-  const apiUrl = (config.entuApiUrl as string) || 'https://entu.app'
+  const apiUrl = (config.public.entuUrl as string) || 'https://api.entu.app'
   const accountName = (config.entuClientId as string) || 'esmuuseum'
 
-  const authUrl = `${apiUrl}/api/auth?account=${accountName}`
+  const authUrl = `${apiUrl}/auth?account=${accountName}`
 
   try {
     const response = await fetch(authUrl, {

--- a/tests/composables/useCompletedTasks.test.ts
+++ b/tests/composables/useCompletedTasks.test.ts
@@ -35,7 +35,7 @@ vi.stubGlobal('useEntuApi', () => ({
 }))
 
 vi.stubGlobal('useRuntimeConfig', () => ({
-  public: { entuUrl: 'https://entu.app', entuAccount: 'esmuuseum' }
+  public: { entuUrl: 'https://api.entu.app', entuAccount: 'esmuuseum' }
 }))
 
 // Need to reset module state between tests

--- a/tests/composables/useEntuApi.test.ts
+++ b/tests/composables/useEntuApi.test.ts
@@ -34,7 +34,7 @@ vi.stubGlobal('useEntuAuth', () => ({
 
 vi.stubGlobal('useRuntimeConfig', () => ({
   public: {
-    entuUrl: 'https://entu.app',
+    entuUrl: 'https://api.entu.app',
     entuAccount: 'esmuuseum'
   }
 }))
@@ -81,13 +81,13 @@ describe('useEntuApi', () => {
   describe('getApiBase', () => {
     it('should return correct base URL', () => {
       const { getApiBase } = useEntuApi()
-      expect(getApiBase()).toBe('https://entu.app/api/esmuuseum')
+      expect(getApiBase()).toBe('https://api.entu.app/esmuuseum')
     })
   })
 
   describe('callApi', () => {
     it('should return parsed JSON response on success', async () => {
-      // The MSW handler for */api/esmuuseum returns account info for valid tokens
+      // The MSW handler for */esmuuseum returns account info for valid tokens
       const { callApi } = useEntuApi()
       const result = await callApi<any>('')
 
@@ -136,7 +136,7 @@ describe('useEntuApi', () => {
     it('should throw on non-ok responses', async () => {
       // Add a custom MSW handler that returns 500
       server.use(
-        http.get('*/api/esmuuseum/custom-error-endpoint', () => {
+        http.get('*/esmuuseum/custom-error-endpoint', () => {
           return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' })
         })
       )
@@ -157,7 +157,7 @@ describe('useEntuApi', () => {
       })
 
       server.use(
-        http.get('*/api/esmuuseum/forbidden-resource', () => {
+        http.get('*/esmuuseum/forbidden-resource', () => {
           return new HttpResponse(null, { status: 403, statusText: 'Forbidden' })
         })
       )
@@ -253,7 +253,7 @@ describe('useEntuApi', () => {
     it('should POST entity data as JSON', async () => {
       // Add MSW handler for entity creation
       server.use(
-        http.post('*/api/esmuuseum/entity', async ({ request }) => {
+        http.post('*/esmuuseum/entity', async ({ request }) => {
           const body = await request.json() as any
           return HttpResponse.json({ _id: 'new-entity-123', ...body })
         })
@@ -273,7 +273,7 @@ describe('useEntuApi', () => {
   describe('updateEntity', () => {
     it('should POST update to entity endpoint', async () => {
       server.use(
-        http.post('*/api/esmuuseum/entity/entity-to-update', async ({ request }) => {
+        http.post('*/esmuuseum/entity/entity-to-update', async ({ request }) => {
           const body = await request.json() as any
           return HttpResponse.json({ _id: 'entity-to-update', ...body })
         })
@@ -289,7 +289,7 @@ describe('useEntuApi', () => {
   describe('deleteEntity', () => {
     it('should send DELETE request', async () => {
       server.use(
-        http.delete('*/api/esmuuseum/entity/entity-to-delete', () => {
+        http.delete('*/esmuuseum/entity/entity-to-delete', () => {
           return HttpResponse.json({ deleted: true })
         })
       )
@@ -322,7 +322,7 @@ describe('useEntuApi', () => {
       const { getAccountInfo } = useEntuApi()
       const result = await getAccountInfo()
 
-      // The MSW handler for */api/esmuuseum returns user data for valid token
+      // The MSW handler for */esmuuseum returns user data for valid token
       expect(result).toBeDefined()
     })
   })

--- a/tests/composables/useOptimisticTaskUpdate.test.ts
+++ b/tests/composables/useOptimisticTaskUpdate.test.ts
@@ -29,7 +29,7 @@ vi.stubGlobal('useCompletedTasks', () => ({
 }))
 
 vi.stubGlobal('useRuntimeConfig', () => ({
-  public: { entuUrl: 'https://entu.app', entuAccount: 'esmuuseum' }
+  public: { entuUrl: 'https://api.entu.app', entuAccount: 'esmuuseum' }
 }))
 
 const { useOptimisticTaskUpdate } = await import('../../app/composables/useOptimisticTaskUpdate')

--- a/tests/composables/useTaskDetail.test.ts
+++ b/tests/composables/useTaskDetail.test.ts
@@ -52,7 +52,7 @@ vi.stubGlobal('useLocation', () => ({
 }))
 
 vi.stubGlobal('useRuntimeConfig', () => ({
-  public: { entuUrl: 'https://entu.app', entuAccount: 'esmuuseum' }
+  public: { entuUrl: 'https://api.entu.app', entuAccount: 'esmuuseum' }
 }))
 
 vi.stubGlobal('useRouter', () => ({ push: vi.fn() }))

--- a/tests/composables/useTaskResponseCreation.test.ts
+++ b/tests/composables/useTaskResponseCreation.test.ts
@@ -38,7 +38,7 @@ vi.stubGlobal('useEntuApi', () => ({
 }))
 
 vi.stubGlobal('useRuntimeConfig', () => ({
-  public: { entuUrl: 'https://entu.app', entuAccount: 'esmuuseum' }
+  public: { entuUrl: 'https://api.entu.app', entuAccount: 'esmuuseum' }
 }))
 
 const mockFetch = vi.fn()

--- a/tests/composables/useTaskWorkspace.test.ts
+++ b/tests/composables/useTaskWorkspace.test.ts
@@ -31,7 +31,7 @@ vi.stubGlobal('useRoute', () => ({
 
 vi.stubGlobal('useRuntimeConfig', () => ({
   public: {
-    entuUrl: 'https://entu.app',
+    entuUrl: 'https://api.entu.app',
     entuAccount: 'esmuuseum'
   }
 }))
@@ -100,7 +100,7 @@ describe('useTaskWorkspace', () => {
 
     vi.stubGlobal('useRuntimeConfig', () => ({
       public: {
-        entuUrl: 'https://entu.app',
+        entuUrl: 'https://api.entu.app',
         entuAccount: 'esmuuseum'
       }
     }))

--- a/tests/helpers/entu-api-mock.ts
+++ b/tests/helpers/entu-api-mock.ts
@@ -86,7 +86,7 @@ export function clearCreatedEntities (): void {
 // MSW Handlers
 // ---------------------------------------------------------------------------
 
-const ENTU_BASE = '*/api/:account'
+const ENTU_BASE = '*/:account'
 
 /**
  * Handler: GET /api/:account/entity/:id
@@ -172,7 +172,7 @@ const entityUpdateHandler = http.post(
  * Returns a mock auth response.
  */
 const authHandler = http.get(
-  '*/api/auth',
+  '*/auth',
   ({ request }) => {
     const authHeader = request.headers.get('authorization')
 

--- a/tests/helpers/nuxt-runtime-mock.ts
+++ b/tests/helpers/nuxt-runtime-mock.ts
@@ -25,11 +25,11 @@ export interface MockRuntimeConfig {
 
 export const defaultMockRuntimeConfig: MockRuntimeConfig = {
   entuKey: 'test-key-not-real',
-  entuApiUrl: 'https://entu.app',
+  entuApiUrl: 'https://api.entu.app',
   entuClientId: 'esmuuseum',
   webhookSecret: 'test-webhook-secret',
   public: {
-    entuUrl: 'https://entu.app',
+    entuUrl: 'https://api.entu.app',
     entuAccount: 'esmuuseum',
     entuClientId: 'test-client-id',
     callbackOrigin: 'http://localhost:3000'

--- a/tests/mocks/entu-auth-api.ts
+++ b/tests/mocks/entu-auth-api.ts
@@ -6,7 +6,7 @@ import { mockTokens, mockUsers, mockAuthResponses } from './jwt-tokens'
 
 export const authApiMocks = [
   // Mock the Entu auth endpoint for token validation
-  http.get('*/api/esmuuseum', ({ request }) => {
+  http.get('*/esmuuseum', ({ request }) => {
     const authHeader = request.headers.get('authorization')
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -42,7 +42,7 @@ export const authApiMocks = [
   }),
 
   // Mock token refresh/authentication endpoint
-  http.get('*/api/auth', ({ request }) => {
+  http.get('*/auth', ({ request }) => {
     const authHeader = request.headers.get('authorization')
     const url = new URL(request.url)
     const account = url.searchParams.get('account')
@@ -71,7 +71,7 @@ export const authApiMocks = [
   }),
 
   // Mock entity endpoints for testing user profile fetching
-  http.get('*/api/esmuuseum/entity/:id', ({ params }) => {
+  http.get('*/esmuuseum/entity/:id', ({ params }) => {
     const { id } = params
 
     if (id === mockUsers.student._id) {
@@ -100,7 +100,7 @@ export const authApiMocks = [
   }),
 
   // Mock search endpoints
-  http.get('*/api/esmuuseum/search', ({ request }) => {
+  http.get('*/esmuuseum/search', ({ request }) => {
     const url = new URL(request.url)
     const typeParam = url.searchParams.get('_type.string')
 
@@ -129,7 +129,7 @@ export const authApiMocks = [
   }),
 
   // Mock rate limiting scenario
-  http.get('*/api/esmuuseum/rate-limited', () => {
+  http.get('*/esmuuseum/rate-limited', () => {
     return new HttpResponse(null, {
       status: 429,
       headers: {
@@ -139,7 +139,7 @@ export const authApiMocks = [
   }),
 
   // Mock server error scenario
-  http.get('*/api/esmuuseum/server-error', () => {
+  http.get('*/esmuuseum/server-error', () => {
     return new HttpResponse(null, { status: 500 })
   })
 ]

--- a/tests/mocks/task-api.ts
+++ b/tests/mocks/task-api.ts
@@ -149,7 +149,7 @@ export const taskApiMocks = [
   }),
 
   // Mock individual entity lookups for referenced entities
-  http.get('*/api/esmuuseum/entity/:id', ({ params, request }) => {
+  http.get('*/esmuuseum/entity/:id', ({ params, request }) => {
     const auth = authenticateRequest(request)
 
     if (!auth.authenticated) {
@@ -211,7 +211,7 @@ export const taskApiMocks = [
   }),
 
   // Mock general search endpoint for testing various queries
-  http.get('*/api/esmuuseum/entity', ({ request }) => {
+  http.get('*/esmuuseum/entity', ({ request }) => {
     const auth = authenticateRequest(request)
 
     if (!auth.authenticated) {

--- a/tests/unit/entu-client.test.ts
+++ b/tests/unit/entu-client.test.ts
@@ -22,7 +22,7 @@ describe('entu-client', () => {
 
       expect(mockFetch).toHaveBeenCalledOnce()
       const [url, options] = mockFetch.mock.calls[0]!
-      expect(url).toBe('https://entu.app/api/esmuuseum/entity/user-123')
+      expect(url).toBe('https://api.entu.app/esmuuseum/entity/user-123')
       expect(options.method).toBe('POST')
       expect(options.headers.Authorization).toBe('Bearer test-token')
       expect(options.headers['Content-Type']).toBe('application/json')
@@ -79,7 +79,7 @@ describe('entu-client', () => {
 
       expect(mockFetch).toHaveBeenCalledOnce()
       const [url, options] = mockFetch.mock.calls[0]!
-      expect(url).toBe('https://entu.app/api/esmuuseum/entity/user-456')
+      expect(url).toBe('https://api.entu.app/esmuuseum/entity/user-456')
       expect(options.method).toBe('POST')
       expect(options.headers.Authorization).toBe('Bearer my-token')
 

--- a/tests/unit/server/auth.test.ts
+++ b/tests/unit/server/auth.test.ts
@@ -201,7 +201,7 @@ describe('server/utils/auth', () => {
   describe('checkTaskPermission', () => {
     const apiConfig = {
       token: 'test-token',
-      apiUrl: 'https://entu.app',
+      apiUrl: 'https://api.entu.app',
       accountName: 'esmuuseum'
     }
 
@@ -262,7 +262,7 @@ describe('server/utils/auth', () => {
   describe('checkResponsePermission', () => {
     const apiConfig = {
       token: 'test-token',
-      apiUrl: 'https://entu.app',
+      apiUrl: 'https://api.entu.app',
       accountName: 'esmuuseum'
     }
 

--- a/tests/unit/server/entu-admin-api.test.ts
+++ b/tests/unit/server/entu-admin-api.test.ts
@@ -57,7 +57,7 @@ describe('server/utils/entu-admin API functions', () => {
     it('should return config with user token', () => {
       const config = getAdminApiConfig('user-jwt-token', 'user-1', 'user@test.ee')
       expect(config.token).toBe('user-jwt-token')
-      expect(config.apiUrl).toBe('https://entu.app')
+      expect(config.apiUrl).toBe('https://api.entu.app')
       expect(config.accountName).toBe('esmuuseum')
     })
 

--- a/tests/unit/server/entu-admin-extractors.test.ts
+++ b/tests/unit/server/entu-admin-extractors.test.ts
@@ -31,7 +31,7 @@ vi.stubGlobal('createError', (opts: { statusCode: number, statusMessage: string 
 // Mock useRuntimeConfig (Nuxt global, used by getAdminApiConfig)
 vi.stubGlobal('useRuntimeConfig', () => ({
   public: {
-    entuUrl: 'https://entu.app',
+    entuUrl: 'https://api.entu.app',
     entuAccount: 'esmuuseum'
   }
 }))

--- a/tests/unit/server/entu.test.ts
+++ b/tests/unit/server/entu.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../../server/utils/logger', () => ({
 
 const apiConfig = {
   token: 'test-token',
-  apiUrl: 'https://entu.app',
+  apiUrl: 'https://api.entu.app',
   accountName: 'esmuuseum'
 }
 

--- a/tests/unit/server/onboard-endpoints.test.ts
+++ b/tests/unit/server/onboard-endpoints.test.ts
@@ -37,7 +37,7 @@ describe('onboard endpoints', () => {
   beforeEach(() => {
     installNuxtMocks({
       entuKey: 'test-key',
-      entuApiUrl: 'https://entu.app',
+      entuApiUrl: 'https://api.entu.app',
       entuClientId: 'esmuuseum'
     })
     // Add entuManagerKey to the config


### PR DESCRIPTION
## Summary
Closes #44. Updates the Entu API URL to use the new host and path structure.

- **Old:** `https://entu.app/api/{account}/endpoint`
- **New:** `https://api.entu.app/{account}/endpoint` (host changed, `/api/` path prefix dropped)

Updates all composables, server utils, env config, and MSW test handlers to reflect the new base URL and path structure.

## Verification
- ✅ `npm run lint` + `npm test` pass
- ✅ Live curl against the real Entu service:
  - `https://api.entu.app/{account}/…` → 200 OK
  - `https://api.entu.app/api/{account}/…` → 404 (old path confirmed dead)
- ✅ URL path change verified empirically, not just inferred

## Notes for reviewer
This commit also bundles some workspace files that were untracked pre-branch (`.claude/startup.md`, `spawn_member.sh`, `.tmux-layout.yaml`, a `.gitignore` tweak, and a scratchpad update). These are scope creep and not part of the #44 fix proper — call out in review if they should be split into a separate commit before merge.

## Test plan
- [ ] CI green
- [ ] Quick manual smoke test: login + task flow on a dev/staging deploy
- [ ] Verify signup/join link (liitumislink) no longer 404s
