### PR TITLE
chore: clean up Entu API URL references (closes #47)

### DIFF
--- a/.config/nuxt.config.ts
+++ b/.config/nuxt.config.ts
@@ -24,7 +24,6 @@ export default defineNuxtConfig({
   spaLoadingTemplate: false,
   runtimeConfig: {
     entuKey: '',
-    entuApiUrl: '',
     entuClientId: '',
     // F020: Webhook security secret
     webhookSecret: '',

--- a/.specify/features/file-upload-spec.md
+++ b/.specify/features/file-upload-spec.md
@@ -31,8 +31,8 @@ This document specifies the end-to-end file upload flow implemented by `import/i
 
 - Endpoint:
   - POST https://{entu_hostname}/{entu_account}/entity/{entity_eid}
-  - In the repo: `entu_hostname = 'entu.app/api'`, `entu_account = 'esmuuseum'`.
-  - Example: `POST https://entu.app/api/esmuuseum/entity/12345`
+  - In the repo: `entu_hostname = 'api.entu.app'`, `entu_account = 'esmuuseum'`.
+  - Example: `POST https://api.entu.app/esmuuseum/entity/12345`
 
 - Headers:
   - `Authorization: Bearer <ENTU_TOKEN>`
@@ -127,7 +127,7 @@ async function uploadFile(entityEid, filename, filePath, token) {
   const filesize = stats.size;
 
   // 1) request upload metadata
-  const postRes = await fetch(`https://entu.app/api/esmuuseum/entity/${entityEid}`, {
+  const postRes = await fetch(`https://api.entu.app/esmuuseum/entity/${entityEid}`, {
     method: 'POST',
     headers: {
       'Accept-Encoding': 'deflate',

--- a/AI_ASSISTANT.md
+++ b/AI_ASSISTANT.md
@@ -315,7 +315,7 @@ Required in `.env`:
 ```bash
 # Entu API Configuration
 NUXT_ENTU_KEY=your_server_side_api_key
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 NUXT_PUBLIC_ENTU_CLIENT_ID=your_oauth_client_id
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ Required in `.env`:
 
 ```bash
 NUXT_ENTU_KEY=your_server_side_api_key
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 NUXT_PUBLIC_ENTU_CLIENT_ID=your_oauth_client_id
 NUXT_WEBHOOK_SECRET=your_webhook_secret

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -315,7 +315,7 @@ Required in `.env`:
 ```bash
 # Entu API Configuration
 NUXT_ENTU_KEY=your_server_side_api_key
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 NUXT_PUBLIC_ENTU_CLIENT_ID=your_oauth_client_id
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -35,7 +35,7 @@ But this is **not recommended** because:
 #### Check Current Callback URL
 When starting OAuth flow, look for logs showing:
 ```
-Full Auth URL: https://entu.app/api/auth/google?account=esmuuseum&next=https%3A//esmuseum.entu.ee/auth/callback%3Fjwt%3D
+Full Auth URL: https://api.entu.app/auth/google?account=esmuuseum&next=https%3A//esmuseum.entu.ee/auth/callback%3Fjwt%3D
 ```
 
 #### Expected Behavior After Fix

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -315,7 +315,7 @@ Required in `.env`:
 ```bash
 # Entu API Configuration
 NUXT_ENTU_KEY=your_server_side_api_key
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 NUXT_PUBLIC_ENTU_CLIENT_ID=your_oauth_client_id
 

--- a/docs/api-requests/entity-types-creation.http
+++ b/docs/api-requests/entity-types-creation.http
@@ -1,7 +1,7 @@
 # Create New Entity Types in Entu
 # This file contains HTTP requests to create the new entity types defined in F001-entu-entity-types.md
 
-@host = entu.app
+@host = api.entu.app
 @account = esmuuseum
 @token = {{esm_token}}
 @esmuuseumEntityId = 66b6245c7efc9ac06a437ba0
@@ -13,7 +13,7 @@
 ###
 # 0. Authenticate to get token
 # @name auth
-GET https://{{host}}/api/auth?account={{account}}
+GET https://{{host}}/auth?account={{account}}
 Authorization: Bearer {{esm_key}}
 
 
@@ -21,7 +21,7 @@ Authorization: Bearer {{esm_key}}
 
 ###
 # 1. Create Kaart entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -40,7 +40,7 @@ Content-Type: application/json
 @kaartEntityId = 686913e11749f351b9c82f1c
 
 ### add "add from" to Kaart entity type
-POST https://{{host}}/api/{{account}}/entity/{{kaartEntityId}} HTTP/1.1
+POST https://{{host}}/{{account}}/entity/{{kaartEntityId}} HTTP/1.1
 Accept-Encoding: deflate
 Authorization: Bearer {{token}}
 Content-Type: application/json; charset=utf-8
@@ -51,7 +51,7 @@ Content-Type: application/json; charset=utf-8
 
 ###
 # 2. Create Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -71,7 +71,7 @@ Content-Type: application/json
 
 ###
 # 3. Create Grupp entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -89,7 +89,7 @@ Content-Type: application/json
 @gruppEntityId = 686914521749f351b9c82f35
 
 ### add "add from" to Grupp entity type
-POST https://{{host}}/api/{{account}}/entity/{{gruppEntityId}} HTTP/1.1
+POST https://{{host}}/{{account}}/entity/{{gruppEntityId}} HTTP/1.1
 Accept-Encoding: deflate
 Authorization: Bearer {{token}}
 Content-Type: application/json; charset=utf-8
@@ -100,7 +100,7 @@ Content-Type: application/json; charset=utf-8
 
 ###
 # 4. Create Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -118,7 +118,7 @@ Content-Type: application/json
 @ulesanneEntityId = 686917231749f351b9c82f4c
 
 ### add "add from" to Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity/{{ulesanneEntityId}} HTTP/1.1
+POST https://{{host}}/{{account}}/entity/{{ulesanneEntityId}} HTTP/1.1
 Accept-Encoding: deflate
 Authorization: Bearer {{token}}
 Content-Type: application/json; charset=utf-8
@@ -129,7 +129,7 @@ Content-Type: application/json; charset=utf-8
 
 ###
 # 5. Create Vastus entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -153,7 +153,7 @@ Content-Type: application/json
 ## 1. Kaart entity type properties
 
 ### 1.1. Create "name" property for Kaart entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -171,7 +171,7 @@ Content-Type: application/json
 ]
 
 ### 1.2. Create "kirjeldus" property for Kaart entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -189,7 +189,7 @@ Content-Type: application/json
 ]
 
 ### 1.3. Create "url" property for Kaart entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -209,7 +209,7 @@ Content-Type: application/json
 ## 2. Asukoht entity type properties
 
 ### 2.1. Create "name" property for Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -227,7 +227,7 @@ Content-Type: application/json
 ]
 
 ### 2.2. Create "kirjeldus" property for Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -245,7 +245,7 @@ Content-Type: application/json
 ]
 
 ### 2.3. Create "long" property for Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -262,7 +262,7 @@ Content-Type: application/json
 ]
 
 ### 2.4. Create "lat" property for Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -279,7 +279,7 @@ Content-Type: application/json
 ]
 
 ### 2.5. Create "photo" property for Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -296,7 +296,7 @@ Content-Type: application/json
 ]
 
 ### 2.6. Create "link" property for Asukoht entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -316,7 +316,7 @@ Content-Type: application/json
 ## 3. Grupp entity type properties
 
 ### 3.1. Create "nimi" property for Grupp entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -334,7 +334,7 @@ Content-Type: application/json
 ]
 
 ### 3.2. Create "kirjeldus" property for Grupp entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -353,7 +353,7 @@ Content-Type: application/json
 ]
 
 ### 3.3. Create "grupijuht" property for Grupp entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -372,7 +372,7 @@ Content-Type: application/json
 ## 4. Ülesanne entity type properties
 
 ### 4.1. Create "nimi" property for Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -390,7 +390,7 @@ Content-Type: application/json
 ]
 
 ### 4.2. Create "kirjeldus" property for Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -408,7 +408,7 @@ Content-Type: application/json
 ]
 
 ### 4.3. Create "tähtaeg" property for Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -424,7 +424,7 @@ Content-Type: application/json
 ]
 
 ### 4.4. Create "kaart" property for Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -441,7 +441,7 @@ Content-Type: application/json
 ]
 
 ### 4.5. Create "grupp" property for Ülesanne entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -460,7 +460,7 @@ Content-Type: application/json
 ## 5. Vastus entity type properties
 
 ### 5.1. Create "asukoht" property for Vastus entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -477,7 +477,7 @@ Content-Type: application/json
 ]
 
 ### 5.2. Create "kirjeldus" property for Vastus entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -495,7 +495,7 @@ Content-Type: application/json
 ]
 
 ### 5.3. Create "photo" property for Vastus entity type
-POST https://{{host}}/api/{{account}}/entity
+POST https://{{host}}/{{account}}/entity
 Authorization: Bearer {{token}}
 Content-Type: application/json
 

--- a/docs/api-requests/entu task responses.http
+++ b/docs/api-requests/entu task responses.http
@@ -1,5 +1,5 @@
 # Entu API HTTP Request Examples
-@api_hostname=entu.app/api
+@api_hostname=api.entu.app
 @account=esmuuseum
 
 ### Entity GET sample response

--- a/docs/api-requests/entu.http
+++ b/docs/api-requests/entu.http
@@ -3,8 +3,7 @@
 # Use with VS Code REST Client extension or similar tools.
 # Replace {{esm_key}} and {{esm_token}} with your own credentials or use environment variables.
 
-# All endpoints are in /api/...
-@api_hostname=entu.app/api
+@api_hostname=api.entu.app
 @account=esmuuseum
 @callback=https://example.com/auth/callback
 

--- a/docs/authentication/entu-authentication.md
+++ b/docs/authentication/entu-authentication.md
@@ -21,7 +21,7 @@ Authentication requires the following environment variables:
 ```dotenv
 # .env file
 NUXT_ENTU_KEY=your_private_entu_key
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 ```
 
@@ -137,7 +137,7 @@ const fetchData = async () => {
 ## References
 
 - Entu API authentication is based on the approach seen in `entity-types-creation.http` and `scripts/fetch-entu-model.js`
-- The authentication endpoint is `https://entu.app/api/auth?account=esmuuseum`
+- The authentication endpoint is `https://api.entu.app/auth?account=esmuuseum`
 - API endpoints require a Bearer token in the Authorization header
 - Token management is handled automatically by the composables
 

--- a/docs/guides/student-task-access-flow.md
+++ b/docs/guides/student-task-access-flow.md
@@ -498,7 +498,7 @@ Both directions = No missing permissions
 
 ```bash
 # Required
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 
 # Optional - for webhook signature validation

--- a/scripts/fetch-entu-model.js
+++ b/scripts/fetch-entu-model.js
@@ -12,7 +12,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 dotenv.config({ path: path.resolve(__dirname, '../.env') })
 
-const HOST = process.env.ENTU_HOST || 'entu.app'
+const HOST = process.env.ENTU_HOST || 'api.entu.app'
 const ACCOUNT = process.env.ENTU_ACCOUNT || 'esmuuseum'
 const ESM_KEY = process.env.ESM_KEY
 
@@ -21,7 +21,7 @@ if (!ESM_KEY) {
   process.exit(1)
 }
 
-const apiBase = `https://${HOST}/api/${ACCOUNT}`
+const apiBase = `https://${HOST}/${ACCOUNT}`
 
 function apiGet (endpoint, token) {
   return new Promise((resolve, reject) => {

--- a/server/api/webhooks/README.md
+++ b/server/api/webhooks/README.md
@@ -94,7 +94,7 @@ Required environment variables:
 
 ```bash
 # Required
-NUXT_PUBLIC_ENTU_URL=https://entu.app
+NUXT_PUBLIC_ENTU_URL=https://api.entu.app
 NUXT_PUBLIC_ENTU_ACCOUNT=esmuuseum
 
 # Optional - for webhook signature validation

--- a/tests/helpers/nuxt-runtime-mock.ts
+++ b/tests/helpers/nuxt-runtime-mock.ts
@@ -12,7 +12,6 @@ import { vi } from 'vitest'
  */
 export interface MockRuntimeConfig {
   entuKey: string
-  entuApiUrl: string
   entuClientId: string
   webhookSecret: string
   public: {
@@ -25,7 +24,6 @@ export interface MockRuntimeConfig {
 
 export const defaultMockRuntimeConfig: MockRuntimeConfig = {
   entuKey: 'test-key-not-real',
-  entuApiUrl: 'https://api.entu.app',
   entuClientId: 'esmuuseum',
   webhookSecret: 'test-webhook-secret',
   public: {

--- a/tests/unit/server/onboard-endpoints.test.ts
+++ b/tests/unit/server/onboard-endpoints.test.ts
@@ -29,15 +29,14 @@ vi.mock('../../../server/utils/logger', () => ({
   })
 }))
 
-// The endpoints use exchangeApiKeyForToken which calls /api/auth.
-// MSW's authHandler handles that. getEntuApiConfig uses config.entuApiUrl and config.entuClientId.
+// The endpoints use exchangeApiKeyForToken which calls /auth.
+// MSW's authHandler handles that. getEntuApiConfig uses config.public.entuUrl and config.entuClientId.
 // We need to match these in the runtime config.
 
 describe('onboard endpoints', () => {
   beforeEach(() => {
     installNuxtMocks({
       entuKey: 'test-key',
-      entuApiUrl: 'https://api.entu.app',
       entuClientId: 'esmuuseum'
     })
     // Add entuManagerKey to the config


### PR DESCRIPTION
## Summary
Closes #47. Follow-up cleanup after #44 (api.entu.app URL migration).

Four commits:

1. **`refactor: remove dead entuApiUrl runtime config key`** — dropped `entuApiUrl` from `nuxt.config.ts` private runtimeConfig (never read after #44), removed from test mock interface + defaults, updated stale comment in `onboard-endpoints.test.ts`.

2. **`fix(scripts): point fetch-entu-model at api.entu.app`** — changed default `HOST` and dropped `/api/` from `apiBase` in `scripts/fetch-entu-model.js`. Sanity-tested: `https://api.entu.app/esmuuseum` is the correct base.

3. **`docs: update Entu API URL references`** — updated old `entu.app/api/...` URLs in `DEPLOYMENT.md`, `docs/api-requests/entu.http`, `docs/api-requests/entu task responses.http`, `docs/authentication/entu-authentication.md`, `.specify/features/file-upload-spec.md`. Historical doc (`docs/demo-feedback-2025-10-08-formalized.md`) left untouched — deliberate record of past state.

4. **`docs: fix NUXT_PUBLIC_ENTU_URL host in env-var examples`** — updated `NUXT_PUBLIC_ENTU_URL=https://entu.app` → `https://api.entu.app` in 6 files missed by the initial grep (pattern lacked `/api/` path so earlier sweep skipped them): `CLAUDE.md`, `COPILOT.md`, `GEMINI.md`, `AI_ASSISTANT.md`, `server/api/webhooks/README.md`, `docs/guides/student-task-access-flow.md`. `specs/029-add-email-authentication/` left untouched — frozen Draft spec from Oct 2025.

## Verification
- ✅ `npm run lint` clean
- ✅ `npm test` — 1006 passed, 3 skipped (no regressions)
- ✅ Script sanity: `apiBase = https://api.entu.app/esmuuseum` confirmed correct

## Test plan
- [ ] CI green
